### PR TITLE
Added basic command argument holder with type conversions

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc17/wrapper/command/FWCommand.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc17/wrapper/command/FWCommand.java
@@ -49,7 +49,7 @@ public class FWCommand implements ICommand {
 	public void processCommand(ICommandSender p_71515_1_, String[] p_71515_2_) {
 		Entity entity = Game.natives().toNova(p_71515_1_);
 		try {
-			command.handle(entity.get(Player.class), p_71515_2_);
+			command.handle(entity.get(Player.class), String.join(" ", p_71515_2_));
 		} catch (Command.CommandException e) {
 			throw new WrongUsageException(e.getMessage());
 		}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc18/wrapper/command/FWCommand.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc18/wrapper/command/FWCommand.java
@@ -49,7 +49,7 @@ public class FWCommand implements ICommand {
 	public void processCommand(ICommandSender p_71515_1_, String[] p_71515_2_) throws CommandException {
 		Entity entity = Game.natives().toNova(p_71515_1_);
 		try {
-			command.handle(entity.get(Player.class), p_71515_2_);
+			command.handle(entity.get(Player.class), String.join(" ", p_71515_2_));
 		} catch (Command.CommandException e) {
 			throw new CommandException(e.getMessage());
 		}

--- a/src/main/java/nova/core/command/Args.java
+++ b/src/main/java/nova/core/command/Args.java
@@ -1,0 +1,249 @@
+package nova.core.command;
+
+import nova.core.command.Command.CommandException;
+
+/**
+ * Class for type conversion and general validation of arguments passed to a
+ * {@link Command}.
+ * 
+ * @author Vic Nightfall
+ */
+public class Args {
+
+	private String[] args;
+
+	public Args(String[] args) {
+		this.args = args;
+	}
+
+	/**
+	 * Returns an immutable copy of the internal argument array
+	 * 
+	 * @return
+	 */
+	public String[] args() {
+		return args.clone();
+	}
+
+	// String
+
+	public String checkString(int index) {
+		checkArg(String.class, index);
+		return args[index];
+	}
+
+	public boolean isString(int index) {
+		return hasArg(index);
+	}
+
+	public String optString(int index, String def) {
+		if (!hasArg(index))
+			return def;
+		return args[index];
+	}
+
+	// Integer
+
+	public int checkInt(int index) {
+		checkArg(int.class, index);
+		try {
+			return Integer.parseInt(args[index]);
+		} catch (NumberFormatException e) {
+			throw TypeException.create(int.class, args[index], index);
+		}
+	}
+
+	public boolean isInt(int index) {
+		if (!hasArg(index))
+			return false;
+		try {
+			Integer.parseInt(args[index]);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public int optInt(int index, int def) {
+		if (!hasArg(index))
+			return def;
+		return checkInt(index);
+	}
+
+	// Float
+
+	public float checkFloat(int index) {
+		checkArg(float.class, index);
+		try {
+			return Float.parseFloat(args[index]);
+		} catch (NumberFormatException e) {
+			throw TypeException.create(float.class, args[index], index);
+		}
+	}
+
+	public boolean isFloat(int index) {
+		if (!hasArg(index))
+			return false;
+		try {
+			Float.parseFloat(args[index]);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public float optFloat(int index, float def) {
+		if (!hasArg(index))
+			return def;
+		return checkFloat(index);
+	}
+
+	// Double
+
+	public double checkDouble(int index) {
+		checkArg(double.class, index);
+		try {
+			return Double.parseDouble(args[index]);
+		} catch (NumberFormatException e) {
+			throw TypeException.create(double.class, args[index], index);
+		}
+	}
+
+	public boolean isDouble(int index) {
+		if (!hasArg(index))
+			return false;
+		try {
+			Double.parseDouble(args[index]);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public double optDouble(int index, double def) {
+		if (!hasArg(index))
+			return def;
+		return checkDouble(index);
+	}
+
+	// Long
+
+	public long checkLong(int index) {
+		checkArg(long.class, index);
+		try {
+			return Long.parseLong(args[index]);
+		} catch (NumberFormatException e) {
+			throw TypeException.create(long.class, args[index], index);
+		}
+	}
+
+	public boolean isLong(int index) {
+		if (!hasArg(index))
+			return false;
+		try {
+			Long.parseLong(args[index]);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public double optLong(int index, long def) {
+		if (!hasArg(index))
+			return def;
+		return checkLong(index);
+	}
+
+	// Boolean
+
+	public boolean checkBoolean(int index) {
+		checkArg(long.class, index);
+		if (!isBoolean(index))
+			throw TypeException.create(boolean.class, args[index], index);
+		return args[index].equalsIgnoreCase("true");
+	}
+
+	public boolean isBoolean(int index) {
+		if (!hasArg(index))
+			return false;
+		return args[index].equalsIgnoreCase("true") || args[index].equalsIgnoreCase("false");
+	}
+
+	public boolean optBoolean(int index, boolean def) {
+		if (!hasArg(index))
+			return def;
+		return checkBoolean(index);
+	}
+
+	// Enum
+
+	public <E extends Enum<E>> E check(Class<E> enumClass, int index) {
+		checkArg(enumClass, index);
+		try {
+			return Enum.valueOf(enumClass, args[index]);
+		} catch (IllegalArgumentException e) {
+			throw TypeException.createEnum(enumClass, args[index], index);
+		}
+	}
+
+	public <E extends Enum<E>> boolean is(Class<E> enumClass, int index) {
+		if (!hasArg(index))
+			return false;
+		try {
+			Enum.valueOf(enumClass, args[index]);
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public <E extends Enum<E>> E opt(Class<E> enumClass, int index, E def) {
+		if (!hasArg(index))
+			return def;
+		return check(enumClass, index);
+	}
+
+	// Misc
+
+	public boolean hasArg(int index) {
+		return index < args.length;
+	}
+
+	private boolean checkArg(Class<?> expected, int index) {
+		if (hasArg(index))
+			return true;
+		else
+			throw new RangeException(expected, index);
+	}
+
+	public static class RangeException extends ArgException {
+		public RangeException(Class<?> expected, int index) {
+			super("Expected %s at index %s, argument not supplied", expected.getClass(), index);
+		}
+	}
+
+	public static class TypeException extends ArgException {
+
+		private TypeException(String message, Object... parameters) {
+			super(message, parameters);
+		}
+
+		public static TypeException create(Class<?> expected, Object received, int index) {
+			return new TypeException("Illegal argument at index %s: Got %s, expected %s", index, received, expected.getSimpleName());
+		}
+
+		public static <E extends Enum<E>> TypeException createEnum(Class<E> expected, Object received, int index) {
+			return new TypeException("Illegal argument at index %s: %s is not a %s %s", index, received, expected.getSimpleName(), expected.getEnumConstants());
+		}
+	}
+
+	public static class ArgException extends CommandException {
+		public ArgException(String message) {
+			super(message);
+		}
+
+		public ArgException(String message, Object... parameters) {
+			super(message, parameters);
+		}
+	}
+}

--- a/src/main/java/nova/core/command/Args.java
+++ b/src/main/java/nova/core/command/Args.java
@@ -203,6 +203,8 @@ public class Args {
 		return check(enumClass, index);
 	}
 
+	// TODO: Player check
+
 	// Misc
 
 	public boolean hasArg(int index) {

--- a/src/main/java/nova/core/command/Command.java
+++ b/src/main/java/nova/core/command/Command.java
@@ -1,19 +1,23 @@
 package nova.core.command;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import nova.core.entity.component.Player;
 import nova.core.util.Identifiable;
 import nova.core.util.NovaException;
-
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * The command type.
  *
  * The ID of the command is the command name.
  *
- * For example, if the command starts with /doSomething ... ...
- * then the ID of the command is "doSomething"
+ * For example, if the command starts with /doSomething ... ... then the ID of
+ * the command is "doSomething"
  *
  * @author Calclavia
  */
@@ -22,15 +26,41 @@ public abstract class Command implements Identifiable {
 	/**
 	 * Handles the command.
 	 *
-	 * Throw a CommandException if the command handling failed.
-	 * The message of the exception will be printed out for the user to see.
-	 * This is useful for cases where the user uses the command incorrectly.
+	 * Throw a CommandException if the command handling failed. The message of
+	 * the exception will be printed out for the user to see. This is useful for
+	 * cases where the user uses the command incorrectly.
 	 *
 	 * @param player The player who sent the command.
-	 * @param params The command parameters separated by spaces
+	 * @param params The command parameters as {@link Args} object
+	 * @throws CommandException
 	 */
-	//TODO: Should we make it throw exceptions, or have a String return value for the message to give the player?
-	public abstract void handle(Player player, String... params) throws CommandException;
+	// TODO: Should we make it throw exceptions, or have a String return value
+	// for the message to give the player?
+	public abstract void handle(Player player, Args params) throws CommandException;
+
+	public final void handle(Player player, String[] params) throws CommandException {
+		handle(player, new Args(params));
+	}
+
+	public final void handle(Player player, String params) throws CommandException {
+		handle(player, new Args(splitParams(params)));
+	}
+
+	private static final Pattern patternSplitParams = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");
+
+	/**
+	 * Returns an array of parameters split on space, considering quotes.
+	 * 
+	 * @param params
+	 * @return
+	 */
+	private static String[] splitParams(String params) {
+		List<String> list = new ArrayList<String>();
+		Matcher m = patternSplitParams.matcher(params);
+		while (m.find())
+			list.add(m.group(1));
+		return list.toArray(new String[list.size()]);
+	}
 
 	/**
 	 * @return A set of alias command names that will also activate the command.

--- a/src/test/java/nova/core/command/CommandTest.java
+++ b/src/test/java/nova/core/command/CommandTest.java
@@ -35,14 +35,10 @@ public class CommandTest {
 
 	public static class ExplodeCommand extends Command {
 		@Override
-		public void handle(Player player, String... params) throws CommandException {
-			if (params.length == 1) {
-				if (params[0] != null && params[0].contains("radius")) {
-					return;
-				}
+		public void handle(Player player, Args params) throws CommandException {
+			if (params.checkString(0).equals("radius")) {
+				
 			}
-
-			throw new CommandException("Invalid command parameters!");
 		}
 
 		@Override

--- a/src/test/java/nova/testutils/NovaAssertions.java
+++ b/src/test/java/nova/testutils/NovaAssertions.java
@@ -52,7 +52,8 @@ public abstract class NovaAssertions extends Assertions{
 
         /**
          * Returns difference between objects.
-         * @param other object from which the difference is to be calculated.
+         * @param actual object from which the difference is to be calculated.
+         * @param other object to which the difference is to be calculated.
          * @return the difference
          */
         protected abstract double difference(T actual, T other);

--- a/src/test/java/nova/testutils/NovaAssertions.java
+++ b/src/test/java/nova/testutils/NovaAssertions.java
@@ -53,7 +53,6 @@ public abstract class NovaAssertions extends Assertions{
         /**
          * Returns difference between objects.
          * @param other object from which the difference is to be calculated.
-         * @param other object to which the difference is to be calculated.
          * @return the difference
          */
         protected abstract double difference(T actual, T other);


### PR DESCRIPTION
Was mentioned here: #155
Since my workspace is currently a nuclear test site, I couldn't apply the changes to the wrapper yet.
I didn't implement range checks for the numeric types since it is a lot of repetitive code and I'm not sure if it is needed.