### PR TITLE
Let event handling happen concurrently on the same bus

### DIFF
--- a/src/main/java/nova/core/event/bus/CancelableEventBus.java
+++ b/src/main/java/nova/core/event/bus/CancelableEventBus.java
@@ -29,11 +29,7 @@ package nova.core.event.bus;
 public class CancelableEventBus<T extends CancelableEvent> extends EventBus<T> {
 	@Override
 	public synchronized void publish(T event) {
-		if (sortedListeners == null) {
-			buildCache();
-		}
-
-		for (EventListenerNode node : sortedListeners) {
+		for (EventListenerNode node : getSortedListeners()) {
 			node.getListener().onEvent(event);
 
 			if (event.isCanceled()) {


### PR DESCRIPTION
Event handlers should either be stateless (i.e. only modify the things passed in through the event) or synchronize on global state.

Subclasses of EventBus can override this behaviour and only allow a single thread to handle events at a time.