### PR TITLE
Fix 1.8 Wrapper Build

### DIFF
--- a/minecraft/1.8/build.gradle
+++ b/minecraft/1.8/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
 jar {
 	manifest {
-		attributes 'FMLCorePlugin': 'nova.core.wrapper.mc18.NovaMinecraftCore'
+		attributes 'FMLCorePlugin': 'nova.core.wrapper.mc.forge.v18.NovaMinecraftCore'
 		attributes 'FMLCorePluginContainsFMLMod': 'true'
 		attributes 'FMLAT': 'nova_at.cfg'
 	}


### PR DESCRIPTION
This PR fixes the `FMLCorePlugin` entry in the 1.8 `MANIFEST.MF` file.
I encountered this bug when I tried running my unofficial build of the latest NOVA, so I fixed it.