### PR TITLE
Implement new Wrapper Events

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/WrapperEvent.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/WrapperEvent.java
@@ -20,10 +20,24 @@
 
 package nova.core.wrapper.mc.forge.v17.util;
 
+import net.minecraft.item.ItemStack;
+import nova.core.block.Block;
+import nova.core.entity.Entity;
 import nova.core.event.BlockEvent;
+import nova.core.event.bus.CancelableEvent;
+import nova.core.event.bus.Event;
+import nova.core.item.Item;
 import nova.core.util.Direction;
 import nova.core.world.World;
+import nova.core.wrapper.mc.forge.v17.wrapper.block.backward.BWBlock;
+import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTile;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.backward.BWEntity;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.forward.FWEntity;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.forward.FWEntityFX;
+import nova.core.wrapper.mc.forge.v17.wrapper.item.BWItem;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+
+import java.util.Optional;
 
 /**
  * @author Calclavia
@@ -57,6 +71,100 @@ public class WrapperEvent {
 		public WeakRedstone(World world, Vector3D position, Direction direction) {
 			super(world, position);
 			this.direction = direction;
+		}
+	}
+
+	public static class BWBlockCreate extends BlockEvent {
+		public final net.minecraft.block.Block mcBlock;
+		public final BWBlock novaBlock;
+
+		public BWBlockCreate(World world, Vector3D position, BWBlock novaBlock, net.minecraft.block.Block mcBlock) {
+			super(world, position);
+			this.novaBlock = novaBlock;
+			this.mcBlock = mcBlock;
+		}
+
+		@Override
+		public boolean isCanceled() {
+			return false;
+		}
+	}
+
+	public static class BWItemCreate extends Event {
+		public final net.minecraft.item.Item mcItem;
+		public final BWItem novaItem;
+		public final Optional<ItemStack> itemStack;
+
+		public BWItemCreate(BWItem novaItem, net.minecraft.item.Item mcItem) {
+			this.novaItem = novaItem;
+			this.mcItem = mcItem;
+			this.itemStack = Optional.empty();
+		}
+
+		public BWItemCreate(BWItem novaItem, net.minecraft.item.Item mcItem, ItemStack itemStack) {
+			this.novaItem = novaItem;
+			this.mcItem = mcItem;
+			this.itemStack = Optional.of(itemStack);
+		}
+	}
+
+	public static class BWEntityCreate extends Event {
+		public final net.minecraft.entity.Entity mcEntity;
+		public final BWEntity novaEntity;
+
+		public BWEntityCreate(BWEntity novaEntity, net.minecraft.entity.Entity mcEntity) {
+			this.novaEntity = novaEntity;
+			this.mcEntity = mcEntity;
+		}
+	}
+
+	public static class BWEntityFXCreate extends Event {
+		public final net.minecraft.client.particle.EntityFX mcEntityFX;
+		public final BWEntity novaEntity;
+
+		public BWEntityFXCreate(BWEntity novaEntity, net.minecraft.client.particle.EntityFX mcEntityFX) {
+			this.novaEntity = novaEntity;
+			this.mcEntityFX = mcEntityFX;
+		}
+	}
+
+	public static class FWTileCreate extends Event {
+		public final Block novaBlock;
+		public final FWTile tileEntity;
+
+		public FWTileCreate(Block novaBlock, FWTile tileEntity) {
+			this.novaBlock = novaBlock;
+			this.tileEntity = tileEntity;
+		}
+	}
+
+	public static class UpdateItemEvent extends Event {
+		public final ItemStack mcItem;
+		public final Item novaItem;
+
+		public UpdateItemEvent(Item novaItem, ItemStack mcItem) {
+			this.novaItem = novaItem;
+			this.mcItem = mcItem;
+		}
+	}
+
+	public static class FWEntityCreate extends Event {
+		public final Entity novaEntity;
+		public final FWEntity mcEntity;
+
+		public FWEntityCreate(Entity novaEntity, FWEntity mcEntity) {
+			this.novaEntity = novaEntity;
+			this.mcEntity = mcEntity;
+		}
+	}
+
+	public static class FWEntityFXCreate extends Event {
+		public final Entity novaEntity;
+		public final FWEntityFX mcEntity;
+
+		public FWEntityFXCreate(Entity novaEntity, FWEntityFX mcEntity) {
+			this.novaEntity = novaEntity;
+			this.mcEntity = mcEntity;
 		}
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
@@ -103,6 +103,10 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 		}
 	}
 
+	public BlockFactory getFactory() {
+		return this.factory;
+	}
+
 	public Block getBlockInstance(net.minecraft.world.IBlockAccess access, Vector3D position) {
 		/**
 		 * If this block has a TileEntity, forward the method into the Stateful

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWTileLoader.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWTileLoader.java
@@ -24,6 +24,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import nova.core.block.Block;
 import nova.core.block.BlockFactory;
 import nova.core.wrapper.mc.forge.v17.asm.lib.ComponentInjector;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
 import nova.internal.core.Game;
 
 import java.util.Optional;
@@ -44,6 +45,8 @@ public final class FWTileLoader {
 			Block block = createBlock(blockID);
 			FWTile tile = injector.inject(block, new Class[0], new Object[0]);
 			tile.setBlock(block);
+			WrapperEvent.FWTileCreate event = new WrapperEvent.FWTileCreate(block, tile);
+			Game.events().publish(event);
 			return tile;
 		} catch (Exception e) {
 			throw new RuntimeException("Fatal error when trying to create a new NOVA tile.", e);
@@ -55,6 +58,8 @@ public final class FWTileLoader {
 			Block block = createBlock(blockID);
 			FWTile tile = injector.inject(block, new Class[] { String.class }, new Object[] { blockID });
 			tile.setBlock(block);
+			WrapperEvent.FWTileCreate event = new WrapperEvent.FWTileCreate(block, tile);
+			Game.events().publish(event);
 			return tile;
 		} catch (Exception e) {
 			throw new RuntimeException("Fatal error when trying to create a new NOVA tile.", e);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/EntityConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/EntityConverter.java
@@ -68,6 +68,9 @@ public class EntityConverter implements NativeConverter<Entity, net.minecraft.en
 
 	@Override
 	public net.minecraft.entity.Entity toNative(Entity novaObj) {
+		if (novaObj instanceof BWEntity)
+			return ((BWEntity) novaObj).entity;
+
 		MCEntityTransform transform = novaObj.components.get(MCEntityTransform.class);
 
 		if (transform.wrapper instanceof FWEntity) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/backward/BWEntity.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/backward/BWEntity.java
@@ -28,8 +28,10 @@ import nova.core.component.misc.Damageable;
 import nova.core.entity.Entity;
 import nova.core.entity.component.Living;
 import nova.core.entity.component.Player;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.forward.MCEntityTransform;
 import nova.core.wrapper.mc.forge.v17.wrapper.inventory.BWInventory;
+import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 /**
@@ -41,6 +43,10 @@ public class BWEntity extends Entity {
 
 	public net.minecraft.entity.Entity entity;
 
+	protected BWEntity() {
+	}
+
+	@SuppressWarnings("unchecked")
 	public BWEntity(net.minecraft.entity.Entity entity) {
 		this.entity = entity;
 		components.add(new MCEntityTransform(entity));
@@ -64,6 +70,9 @@ public class BWEntity extends Entity {
 				living.faceDisplacement = () -> Vector3D.PLUS_J.scalarMultiply(entity.getEyeHeight());
 			}
 		}
+
+		WrapperEvent.BWEntityCreate event = new WrapperEvent.BWEntityCreate(this, entity);
+		Game.events().publish(event);
 	}
 
 	public static class MCPlayer extends Player {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/backward/BWEntityFX.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/backward/BWEntityFX.java
@@ -51,6 +51,8 @@ import net.minecraft.client.particle.EntitySnowShovelFX;
 import net.minecraft.client.particle.EntitySpellParticleFX;
 import net.minecraft.client.particle.EntitySplashFX;
 import net.minecraft.client.particle.EntitySuspendFX;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
+import nova.internal.core.Game;
 
 /**
  * A backward entity particle that acts as a black box, which wraps a Minecraft particle fxs.
@@ -106,14 +108,16 @@ public class BWEntityFX extends BWEntity {
 	public final String particleID;
 
 	public BWEntityFX(String particleID) {
-		//TODO: NPE?
-		super(null);
+		super();
 		this.particleID = particleID;
 	}
 
 	public EntityFX createEntityFX() {
 		//Look up for particle factory and pass it into BWEntityFX
 		//TODO: Handle velocity?
-		return FMLClientHandler.instance().getClient().renderGlobal.doSpawnParticle(particleID, 0, 0, 0, 0, 0, 0);
+		EntityFX entity = FMLClientHandler.instance().getClient().renderGlobal.doSpawnParticle(particleID, 0, 0, 0, 0, 0, 0);
+		WrapperEvent.BWEntityFXCreate event = new WrapperEvent.BWEntityFXCreate(this, entity);
+		Game.events().publish(event);
+		return entity;
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntity.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntity.java
@@ -33,6 +33,7 @@ import nova.core.entity.EntityFactory;
 import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.shape.Cuboid;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
@@ -123,6 +124,8 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 		if (wrapped != null) {
 			wrapped.events.publish(new Stateful.LoadEvent());
 			updateCollider();
+			WrapperEvent.FWEntityCreate event = new WrapperEvent.FWEntityCreate(wrapped, this);
+			Game.events().publish(event);
 		}
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntityFX.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntityFX.java
@@ -34,6 +34,8 @@ import nova.core.entity.Entity;
 import nova.core.entity.EntityFactory;
 import nova.core.util.shape.Cuboid;
 import nova.core.wrapper.mc.forge.v17.render.RenderUtility;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
+import nova.internal.core.Game;
 
 /**
  * A copy of BWEntity that extends EntityFX
@@ -99,6 +101,8 @@ public class FWEntityFX extends EntityFX {
 			prevRotationYaw = rotationYaw;
 			prevRotationPitch = rotationPitch;
 			setPosition(posX, posY, posZ);
+			WrapperEvent.FWEntityFXCreate event = new WrapperEvent.FWEntityFXCreate(wrapped, this);
+			Game.events().publish(event);
 		}
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/BWItemFactory.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/BWItemFactory.java
@@ -25,6 +25,7 @@ import nova.core.component.misc.FactoryProvider;
 import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.retention.Data;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
 import nova.internal.core.Game;
 
 /**
@@ -57,6 +58,8 @@ public class BWItemFactory extends ItemFactory {
 		NBTTagCompound nbtData = Game.natives().toNative(data);
 		BWItem bwItem = new BWItem(item, meta, nbtData);
 		bwItem.components.add(new FactoryProvider(this));
+		WrapperEvent.BWItemCreate event = new WrapperEvent.BWItemCreate(bwItem, item);
+		Game.events().publish(event);
 		return bwItem;
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
@@ -36,6 +36,7 @@ import nova.core.retention.Data;
 import nova.core.wrapper.mc.forge.v17.launcher.ForgeLoadable;
 import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v17.wrapper.CategoryConverter;
+import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.BlockConverter;
 import nova.internal.core.Game;
 import nova.internal.core.launch.InitializationException;
@@ -151,6 +152,8 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 			return null;
 		}
 		itemStack.setTagCompound(Game.natives().toNative(item.getFactory().save(item)));
+		WrapperEvent.UpdateItemEvent event = new WrapperEvent.UpdateItemEvent(item, itemStack);
+		Game.events().publish(event);
 		return itemStack;
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/WrapperEvent.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/WrapperEvent.java
@@ -20,10 +20,24 @@
 
 package nova.core.wrapper.mc.forge.v18.util;
 
+import net.minecraft.item.ItemStack;
+import nova.core.block.Block;
+import nova.core.entity.Entity;
 import nova.core.event.BlockEvent;
+import nova.core.event.bus.CancelableEvent;
+import nova.core.event.bus.Event;
+import nova.core.item.Item;
 import nova.core.util.Direction;
 import nova.core.world.World;
+import nova.core.wrapper.mc.forge.v18.wrapper.block.backward.BWBlock;
+import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTile;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.backward.BWEntity;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.FWEntity;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.FWEntityFX;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.BWItem;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+
+import java.util.Optional;
 
 /**
  * Events for wrappers to hook into
@@ -58,6 +72,100 @@ public class WrapperEvent {
 		public WeakRedstone(World world, Vector3D position, Direction direction) {
 			super(world, position);
 			this.direction = direction;
+		}
+	}
+
+	public static class BWBlockCreate extends BlockEvent {
+		public final net.minecraft.block.Block mcBlock;
+		public final BWBlock novaBlock;
+
+		public BWBlockCreate(World world, Vector3D position, BWBlock novaBlock, net.minecraft.block.Block mcBlock) {
+			super(world, position);
+			this.novaBlock = novaBlock;
+			this.mcBlock = mcBlock;
+		}
+
+		@Override
+		public boolean isCanceled() {
+			return false;
+		}
+	}
+
+	public static class BWItemCreate extends Event {
+		public final net.minecraft.item.Item mcItem;
+		public final BWItem novaItem;
+		public final Optional<ItemStack> itemStack;
+
+		public BWItemCreate(BWItem novaItem, net.minecraft.item.Item mcItem) {
+			this.novaItem = novaItem;
+			this.mcItem = mcItem;
+			this.itemStack = Optional.empty();
+		}
+
+		public BWItemCreate(BWItem novaItem, net.minecraft.item.Item mcItem, ItemStack itemStack) {
+			this.novaItem = novaItem;
+			this.mcItem = mcItem;
+			this.itemStack = Optional.of(itemStack);
+		}
+	}
+
+	public static class BWEntityCreate extends Event {
+		public final net.minecraft.entity.Entity mcEntity;
+		public final BWEntity novaEntity;
+
+		public BWEntityCreate(BWEntity novaEntity, net.minecraft.entity.Entity mcEntity) {
+			this.novaEntity = novaEntity;
+			this.mcEntity = mcEntity;
+		}
+	}
+
+	public static class BWEntityFXCreate extends Event {
+		public final net.minecraft.client.particle.EntityFX mcEntityFX;
+		public final BWEntity novaEntity;
+
+		public BWEntityFXCreate(BWEntity novaEntity, net.minecraft.client.particle.EntityFX mcEntityFX) {
+			this.novaEntity = novaEntity;
+			this.mcEntityFX = mcEntityFX;
+		}
+	}
+
+	public static class UpdateItemEvent extends Event {
+		public final ItemStack mcItem;
+		public final Item novaItem;
+
+		public UpdateItemEvent(Item novaItem, ItemStack mcItem) {
+			this.novaItem = novaItem;
+			this.mcItem = mcItem;
+		}
+	}
+
+	public static class FWTileCreate extends Event {
+		public final Block novaBlock;
+		public final FWTile tileEntity;
+
+		public FWTileCreate(Block novaBlock, FWTile tileEntity) {
+			this.novaBlock = novaBlock;
+			this.tileEntity = tileEntity;
+		}
+	}
+
+	public static class FWEntityCreate extends Event {
+		public final Entity novaEntity;
+		public final FWEntity mcEntity;
+
+		public FWEntityCreate(Entity novaEntity, FWEntity mcEntity) {
+			this.novaEntity = novaEntity;
+			this.mcEntity = mcEntity;
+		}
+	}
+
+	public static class FWEntityFXCreate extends Event {
+		public final Entity novaEntity;
+		public final FWEntityFX mcEntity;
+
+		public FWEntityFXCreate(Entity novaEntity, FWEntityFX mcEntity) {
+			this.novaEntity = novaEntity;
+			this.mcEntity = mcEntity;
 		}
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/forward/FWTileLoader.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/forward/FWTileLoader.java
@@ -25,6 +25,7 @@ import nova.core.block.Block;
 import nova.core.block.BlockFactory;
 import nova.core.component.Updater;
 import nova.core.wrapper.mc.forge.v18.asm.lib.ComponentInjector;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
 import nova.internal.core.Game;
 
 import java.util.Optional;
@@ -44,8 +45,11 @@ public final class FWTileLoader {
 		try {
 			String blockID = data.getString("novaID");
 			Block block = createBlock(blockID);
-			FWTile tile = (block instanceof Updater) ? updaterInjector.inject(block, new Class[0], new Object[0]) : injector.inject(block, new Class[0], new Object[0]);
+			ComponentInjector<? extends FWTile> inject = (block instanceof Updater) ? updaterInjector : injector;
+			FWTile tile = inject.inject(block, new Class<?>[0], new Object[0]);
 			tile.setBlock(block);
+			WrapperEvent.FWTileCreate event = new WrapperEvent.FWTileCreate(block, tile);
+			Game.events().publish(event);
 			return tile;
 		} catch (Exception e) {
 			throw new RuntimeException("Fatal error when trying to create a new NOVA tile.", e);
@@ -55,9 +59,11 @@ public final class FWTileLoader {
 	public static FWTile loadTile(String blockID) {
 		try {
 			Block block = createBlock(blockID);
-			FWTile tile = (block instanceof Updater) ? updaterInjector.inject(block, new Class[] { String.class }, new Object[] { blockID }) : injector.inject(block, new Class[] {
-				String.class }, new Object[] { blockID });
+			ComponentInjector<? extends FWTile> inject = (block instanceof Updater) ? updaterInjector : injector;
+			FWTile tile = inject.inject(block, new Class<?>[] { String.class }, new Object[] { blockID });
 			tile.setBlock(block);
+			WrapperEvent.FWTileCreate event = new WrapperEvent.FWTileCreate(block, tile);
+			Game.events().publish(event);
 			return tile;
 		} catch (Exception e) {
 			throw new RuntimeException("Fatal error when trying to create a new NOVA tile.", e);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/EntityConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/EntityConverter.java
@@ -69,6 +69,9 @@ public class EntityConverter implements NativeConverter<Entity, net.minecraft.en
 
 	@Override
 	public net.minecraft.entity.Entity toNative(Entity novaObj) {
+		if (novaObj instanceof BWEntity)
+			return ((BWEntity) novaObj).entity;
+
 		MCEntityTransform transform = novaObj.components.get(MCEntityTransform.class);
 
 		if (transform.wrapper instanceof FWEntity) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/backward/BWEntity.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/backward/BWEntity.java
@@ -28,8 +28,10 @@ import nova.core.component.misc.Damageable;
 import nova.core.entity.Entity;
 import nova.core.entity.component.Living;
 import nova.core.entity.component.Player;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.MCEntityTransform;
 import nova.core.wrapper.mc.forge.v18.wrapper.inventory.BWInventory;
+import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 /**
@@ -41,6 +43,10 @@ public class BWEntity extends Entity {
 
 	public net.minecraft.entity.Entity entity;
 
+	protected BWEntity() {
+	}
+
+	@SuppressWarnings("unchecked")
 	public BWEntity(net.minecraft.entity.Entity entity) {
 		this.entity = entity;
 		components.add(new MCEntityTransform(entity));
@@ -64,6 +70,9 @@ public class BWEntity extends Entity {
 				living.faceDisplacement = () -> Vector3D.PLUS_J.scalarMultiply(entity.getEyeHeight());
 			}
 		}
+
+		WrapperEvent.BWEntityCreate event = new WrapperEvent.BWEntityCreate(this, entity);
+		Game.events().publish(event);
 	}
 
 	public static class MCPlayer extends Player {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/backward/BWEntityFX.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/backward/BWEntityFX.java
@@ -56,6 +56,8 @@ import net.minecraft.client.particle.IParticleFactory;
 import net.minecraft.client.particle.MobAppearance;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraftforge.fml.client.FMLClientHandler;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
+import nova.internal.core.Game;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -159,14 +161,16 @@ public class BWEntityFX extends BWEntity {
 	private final int particleID;
 
 	public BWEntityFX(int particleID) {
-		//TODO: NPE
-		super(null);
+		super();
 		this.particleID = particleID;
 	}
 
 	public EntityFX createEntityFX(net.minecraft.world.World world) {
 		//Look up for particle factory and pass it into BWEntityFX
 		IParticleFactory particleFactory = (IParticleFactory) FMLClientHandler.instance().getClient().effectRenderer.field_178932_g.get(particleID);
-		return particleFactory.getEntityFX(0, world, 0, 0, 0, 0, 0, 0, 0);
+		EntityFX entity = particleFactory.getEntityFX(0, world, 0, 0, 0, 0, 0, 0, 0);
+		WrapperEvent.BWEntityFXCreate event = new WrapperEvent.BWEntityFXCreate(this, entity);
+		Game.events().publish(event);
+		return entity;
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntity.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntity.java
@@ -33,6 +33,7 @@ import nova.core.entity.EntityFactory;
 import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.shape.Cuboid;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v18.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
@@ -123,6 +124,8 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 		if (wrapped != null) {
 			wrapped.events.publish(new Stateful.LoadEvent());
 			updateCollider();
+			WrapperEvent.FWEntityCreate event = new WrapperEvent.FWEntityCreate(wrapped, this);
+			Game.events().publish(event);
 		}
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntityFX.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntityFX.java
@@ -35,6 +35,8 @@ import nova.core.entity.Entity;
 import nova.core.entity.EntityFactory;
 import nova.core.util.shape.Cuboid;
 import nova.core.wrapper.mc.forge.v18.render.RenderUtility;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
+import nova.internal.core.Game;
 
 /**
  * A copy of BWEntity that extends EntityFX
@@ -100,6 +102,8 @@ public class FWEntityFX extends EntityFX {
 			prevRotationYaw = rotationYaw;
 			prevRotationPitch = rotationPitch;
 			setPosition(posX, posY, posZ);
+			WrapperEvent.FWEntityFXCreate event = new WrapperEvent.FWEntityFXCreate(wrapped, this);
+			Game.events().publish(event);
 		}
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/BWItemFactory.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/BWItemFactory.java
@@ -25,6 +25,7 @@ import nova.core.component.misc.FactoryProvider;
 import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.retention.Data;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
 import nova.internal.core.Game;
 
 /**
@@ -57,6 +58,8 @@ public class BWItemFactory extends ItemFactory {
 		NBTTagCompound nbtData = Game.natives().toNative(data);
 		BWItem bwItem = new BWItem(item, meta, nbtData);
 		bwItem.components.add(new FactoryProvider(this));
+		WrapperEvent.BWItemCreate event = new WrapperEvent.BWItemCreate(bwItem, item);
+		Game.events().publish(event);
 		return bwItem;
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
@@ -37,6 +37,7 @@ import nova.core.nativewrapper.NativeConverter;
 import nova.core.retention.Data;
 import nova.core.wrapper.mc.forge.v18.launcher.ForgeLoadable;
 import nova.core.wrapper.mc.forge.v18.launcher.NovaMinecraft;
+import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.BlockConverter;
 import nova.internal.core.Game;
 import nova.internal.core.launch.InitializationException;
@@ -153,6 +154,8 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 		}
 
 		itemStack.setTagCompound(Game.natives().toNative(item.getFactory().save(item)));
+		WrapperEvent.UpdateItemEvent event = new WrapperEvent.UpdateItemEvent(item, itemStack);
+		Game.events().publish(event);
 		return itemStack;
 	}
 


### PR DESCRIPTION
Needed for wrappers to add wrapper-specific Components to backward wrappers.
For 1.9+: Needed for wrappers to add wrapper-specific Forge Capabilities (Forge’s equivalent of NOVA Components) to forward wrappers (eg. NOVA-Team/NOVA-Energy#4).

---

Split off from #235