### PR TITLE
Implement ItemIngredient.consumeOnCrafting in subclasses

### DIFF
--- a/src/main/java/nova/core/recipes/crafting/OreItemIngredient.java
+++ b/src/main/java/nova/core/recipes/crafting/OreItemIngredient.java
@@ -74,6 +74,6 @@ public class OreItemIngredient implements ItemIngredient {
 
 	@Override
 	public Item consumeOnCrafting(Item original, CraftingGrid craftingGrid) {
-		return null;
+		return original.withAmount(original.count() - 1);
 	}
 }

--- a/src/main/java/nova/core/recipes/crafting/ShapedCraftingRecipe.java
+++ b/src/main/java/nova/core/recipes/crafting/ShapedCraftingRecipe.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -256,6 +257,7 @@ public class ShapedCraftingRecipe implements CraftingRecipe {
 		for (int i = 0; i < ingredients.length; i++) {
 			Item original = mapping.Items[i];
 			Item consumed = ingredients[i].consumeOnCrafting(original, craftingGrid);
+			Objects.requireNonNull(consumed, "The result of 'ItemIngredient.consumeOnCrafting' can't be null");
 
 			// -- only works if Item is immutable
 			//if (original == consumed)

--- a/src/main/java/nova/core/recipes/crafting/ShapelessCraftingRecipe.java
+++ b/src/main/java/nova/core/recipes/crafting/ShapelessCraftingRecipe.java
@@ -24,6 +24,7 @@ import nova.core.item.Item;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -119,8 +120,9 @@ public class ShapelessCraftingRecipe implements CraftingRecipe {
 
 		for (int i = 0; i < ingredients.length; i++) {
 			ItemIngredient ingredient = ingredients[i];
-			Item transformed = ingredient.consumeOnCrafting(matching.inputs[i], craftingGrid);
-			craftingGrid.setStack(matching.indices[i], Optional.ofNullable(transformed));
+			Item consumed = ingredient.consumeOnCrafting(matching.inputs[i], craftingGrid);
+			Objects.requireNonNull(consumed, "The result of 'ItemIngredient.consumeOnCrafting' can't be null");
+			craftingGrid.setStack(matching.indices[i], Optional.ofNullable(consumed));
 		}
 	}
 

--- a/src/main/java/nova/core/recipes/crafting/SpecificItemIngredient.java
+++ b/src/main/java/nova/core/recipes/crafting/SpecificItemIngredient.java
@@ -69,7 +69,7 @@ public class SpecificItemIngredient implements ItemIngredient {
 
 	@Override
 	public Item consumeOnCrafting(Item original, CraftingGrid craftingGrid) {
-		return original;
+		return original.withAmount(original.count() - 1);
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes a `NullPointerException` in `ShapedCraftingRecipe`.