### PR TITLE
Decouple Categories from Minecraft

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/NovaMinecraft.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/NovaMinecraft.java
@@ -45,6 +45,7 @@ import nova.core.wrapper.mc.forge.v17.depmodules.RenderModule;
 import nova.core.wrapper.mc.forge.v17.depmodules.SaveModule;
 import nova.core.wrapper.mc.forge.v17.depmodules.TickerModule;
 import nova.core.wrapper.mc.forge.v17.recipes.MinecraftRecipeRegistry;
+import nova.core.wrapper.mc.forge.v17.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.DirectionConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.BlockConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
@@ -123,6 +124,7 @@ public class NovaMinecraft {
 			Game.natives().registerConverter(new CuboidConverter());
 			Game.natives().registerConverter(new InventoryConverter());
 			Game.natives().registerConverter(new DirectionConverter());
+			Game.natives().registerConverter(new CategoryConverter());
 
 			/**
 			 * Initiate recipe and ore dictionary integration

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/ModCreativeTab.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/ModCreativeTab.java
@@ -22,25 +22,31 @@ package nova.core.wrapper.mc.forge.v17.util;
 
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 /**
  * @author Calclavia
  */
 public class ModCreativeTab extends CreativeTabs {
-	public Item item;
+	public ItemStack item;
 
-	public ModCreativeTab(String label, Item item) {
+	public ModCreativeTab(String label, ItemStack item) {
 		super(label);
 
 		this.item = item;
 	}
 
 	public ModCreativeTab(String label) {
-		this(label, null);
+		this(label, new ItemStack((Item) null));
+	}
+
+	@Override
+	public ItemStack getIconItemStack() {
+		return item;
 	}
 
 	@Override
 	public Item getTabIconItem() {
-		return item;
+		return item.getItem();
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/CategoryConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/CategoryConverter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nova.core.wrapper.mc.forge.v17.wrapper;
+
+import net.minecraft.block.Block;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import nova.core.component.Category;
+import nova.core.nativewrapper.NativeConverter;
+import nova.core.wrapper.mc.forge.v17.util.ModCreativeTab;
+import nova.core.wrapper.mc.forge.v17.wrapper.item.ItemConverter;
+import nova.internal.core.Game;
+
+import java.util.Arrays;
+
+/**
+ * Converts NOVA {@link Category Categories} to Minecraft {@link CreativeTabs} and back.
+ *
+ * @author ExE Boss
+ */
+public class CategoryConverter implements NativeConverter<Category, CreativeTabs>{
+
+	public static CategoryConverter instance() {
+		return (CategoryConverter) Game.natives().getNative(Category.class, CreativeTabs.class);
+	}
+
+	@Override
+	public Class<Category> getNovaSide() {
+		return Category.class;
+	}
+
+	@Override
+	public Class<CreativeTabs> getNativeSide() {
+		return CreativeTabs.class;
+	}
+
+	@Override
+	public Category toNova(CreativeTabs creativeTab) {
+		switch (creativeTab.getTabLabel()) {
+			case "buildingBlocks":
+				return Category.BUILDING_BLOCKS;
+			case "decorations":
+				return Category.DECORATIONS;
+			case "redstone":
+				return Category.TECHNOLOGY;
+			case "transportation":
+				return Category.TRANSPORTATION;
+			case "food":
+				return Category.FOOD;
+			case "tools":
+				return Category.TOOLS;
+			case "combat":
+				return Category.COMBAT;
+			case "brewing":
+				return Category.ALCHEMY;
+			case "materials":
+				return Category.MATERIALS;
+			case "misc":
+				return Category.MISCELLANEOUS;
+			default:
+				return new Category(creativeTab.getTabLabel(), ItemConverter.instance().toNova(creativeTab.getIconItemStack()));
+		}
+	}
+
+	@Override
+	public CreativeTabs toNative(Category category) {
+		return toNative(category, new ItemStack((Item) null));
+	}
+
+	public CreativeTabs toNative(Category category, Block block) {
+		return toNative(category, new ItemStack(block));
+	}
+
+	public CreativeTabs toNative(Category category, Item item) {
+		return toNative(category, new ItemStack(item));
+	}
+
+	public CreativeTabs toNative(Category category, ItemStack item) {
+		if (category.name.startsWith("nova:")) {
+			switch (category.name) {
+				case Category.BUILDING_BLOCKS_NAME:
+					return CreativeTabs.tabBlock;
+				case Category.DECORATIONS_NAME:
+					return CreativeTabs.tabDecorations;
+				case Category.TECHNOLOGY_NAME:
+					return CreativeTabs.tabRedstone;
+				case Category.TRANSPORTATION_NAME:
+					return CreativeTabs.tabTransport;
+				case Category.FOOD_NAME:
+					return CreativeTabs.tabFood;
+				case Category.TOOLS_NAME:
+					return CreativeTabs.tabTools;
+				case Category.COMBAT_NAME:
+					return CreativeTabs.tabCombat;
+				case Category.ALCHEMY_NAME:
+					return CreativeTabs.tabBrewing;
+				case Category.MATERIALS_NAME:
+					return CreativeTabs.tabMaterials;
+				case Category.MISCELLANEOUS_NAME:
+					return CreativeTabs.tabMisc;
+			}
+		}
+		return Arrays.stream(CreativeTabs.creativeTabArray)
+			.filter(tab -> tab.getTabLabel().equals(category.name))
+			.findFirst()
+			.orElseGet(() -> new ModCreativeTab(category.name, category.item.map(ItemConverter.instance()::toNative).orElse(item)));
+	}
+}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
@@ -22,9 +22,7 @@ package nova.core.wrapper.mc.forge.v17.wrapper.block;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
-import net.minecraft.item.Item;
 import nova.core.block.Block;
 import nova.core.block.BlockFactory;
 import nova.core.block.BlockManager;
@@ -33,15 +31,13 @@ import nova.core.event.BlockEvent;
 import nova.core.loader.Loadable;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
-import nova.core.wrapper.mc.forge.v17.util.ModCreativeTab;
+import nova.core.wrapper.mc.forge.v17.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.backward.BWBlock;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v17.wrapper.item.FWItemBlock;
 import nova.internal.core.Game;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Optional;
 
 /**
  * @author Calclavia
@@ -141,16 +137,7 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 		if (blockWrapper.dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {
 			//Add into creative tab
 			Category category = blockWrapper.dummy.components.get(Category.class);
-			Optional<CreativeTabs> first = Arrays.stream(CreativeTabs.creativeTabArray)
-				.filter(tab -> tab.getTabLabel().equals(category.name))
-				.findFirst();
-			if (first.isPresent()) {
-				blockWrapper.setCreativeTab(first.get());
-			} else {
-				Optional<nova.core.item.Item> item = category.item;
-				ModCreativeTab tab = new ModCreativeTab(category.name, item.isPresent() ? Game.natives().toNative(item.get()) : Item.getItemFromBlock(blockWrapper));
-				blockWrapper.setCreativeTab(tab);
-			}
+			blockWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, blockWrapper));
 		}
 
 		System.out.println("[NOVA]: Registered '" + blockFactory.getID() + "' block.");

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
@@ -23,7 +23,6 @@ package nova.core.wrapper.mc.forge.v17.wrapper.item;
 import com.google.common.collect.HashBiMap;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import nova.core.block.BlockFactory;
 import nova.core.component.Category;
@@ -35,13 +34,11 @@ import nova.core.loader.Loadable;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.retention.Data;
 import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
-import nova.core.wrapper.mc.forge.v17.util.ModCreativeTab;
+import nova.core.wrapper.mc.forge.v17.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.BlockConverter;
 import nova.internal.core.Game;
 import nova.internal.core.launch.InitializationException;
 
-import java.util.Arrays;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -206,16 +203,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, Loadable
 			if (dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {
 				//Add into creative tab
 				Category category = dummy.components.get(Category.class);
-				Optional<CreativeTabs> first = Arrays.stream(CreativeTabs.creativeTabArray)
-					.filter(tab -> tab.getTabLabel().equals(category.name))
-					.findFirst();
-				if (first.isPresent()) {
-					itemWrapper.setCreativeTab(first.get());
-				} else {
-					Optional<Item> item = category.item;
-					ModCreativeTab tab = new ModCreativeTab(category.name, item.isPresent() ? Game.natives().toNative(item.get()) : itemWrapper);
-					itemWrapper.setCreativeTab(tab);
-				}
+				itemWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, itemWrapper));
 			}
 
 			System.out.println("[NOVA]: Registered '" + itemFactory.getID() + "' item.");

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
@@ -45,6 +45,7 @@ import nova.core.wrapper.mc.forge.v18.depmodules.RenderModule;
 import nova.core.wrapper.mc.forge.v18.depmodules.SaveModule;
 import nova.core.wrapper.mc.forge.v18.depmodules.TickerModule;
 import nova.core.wrapper.mc.forge.v18.recipes.MinecraftRecipeRegistry;
+import nova.core.wrapper.mc.forge.v18.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.DirectionConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.VectorConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.BlockConverter;
@@ -125,6 +126,7 @@ public class NovaMinecraft {
 			Game.natives().registerConverter(new InventoryConverter());
 			Game.natives().registerConverter(new VectorConverter());
 			Game.natives().registerConverter(new DirectionConverter());
+			Game.natives().registerConverter(new CategoryConverter());
 
 			/**
 			 * Initiate recipe and ore dictionary integration

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/ModCreativeTab.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/ModCreativeTab.java
@@ -22,25 +22,31 @@ package nova.core.wrapper.mc.forge.v18.util;
 
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 /**
  * @author Calclavia
  */
 public class ModCreativeTab extends CreativeTabs {
-	public Item item;
+	public ItemStack item;
 
-	public ModCreativeTab(String label, Item item) {
+	public ModCreativeTab(String label, ItemStack item) {
 		super(label);
 
 		this.item = item;
 	}
 
 	public ModCreativeTab(String label) {
-		this(label, null);
+		this(label, new ItemStack((net.minecraft.item.Item) null));
+	}
+
+	@Override
+	public ItemStack getIconItemStack() {
+		return item;
 	}
 
 	@Override
 	public Item getTabIconItem() {
-		return item;
+		return item.getItem();
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/CategoryConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/CategoryConverter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nova.core.wrapper.mc.forge.v18.wrapper;
+
+import net.minecraft.block.Block;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import nova.core.component.Category;
+import nova.core.nativewrapper.NativeConverter;
+import nova.core.wrapper.mc.forge.v18.util.ModCreativeTab;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
+import nova.internal.core.Game;
+
+import java.util.Arrays;
+
+/**
+ * Converts NOVA {@link Category Categories} to Minecraft {@link CreativeTabs} and back.
+ *
+ * @author ExE Boss
+ */
+public class CategoryConverter implements NativeConverter<Category, CreativeTabs>{
+
+	public static CategoryConverter instance() {
+		return (CategoryConverter) Game.natives().getNative(Category.class, CreativeTabs.class);
+	}
+
+	@Override
+	public Class<Category> getNovaSide() {
+		return Category.class;
+	}
+
+	@Override
+	public Class<CreativeTabs> getNativeSide() {
+		return CreativeTabs.class;
+	}
+
+	@Override
+	public Category toNova(CreativeTabs creativeTab) {
+		switch (creativeTab.getTabLabel()) {
+			case "buildingBlocks":
+				return Category.BUILDING_BLOCKS;
+			case "decorations":
+				return Category.DECORATIONS;
+			case "redstone":
+				return Category.TECHNOLOGY;
+			case "transportation":
+				return Category.TRANSPORTATION;
+			case "food":
+				return Category.FOOD;
+			case "tools":
+				return Category.TOOLS;
+			case "combat":
+				return Category.COMBAT;
+			case "brewing":
+				return Category.ALCHEMY;
+			case "materials":
+				return Category.MATERIALS;
+			case "misc":
+				return Category.MISCELLANEOUS;
+			default:
+				return new Category(creativeTab.getTabLabel(), ItemConverter.instance().toNova(creativeTab.getIconItemStack()));
+		}
+	}
+
+	@Override
+	public CreativeTabs toNative(Category category) {
+		return toNative(category, new ItemStack((Item) null));
+	}
+
+	public CreativeTabs toNative(Category category, Block block) {
+		return toNative(category, new ItemStack(block));
+	}
+
+	public CreativeTabs toNative(Category category, Item item) {
+		return toNative(category, new ItemStack(item));
+	}
+
+	public CreativeTabs toNative(Category category, ItemStack item) {
+		if (category.name.startsWith("nova:")) {
+			switch (category.name) {
+				case Category.BUILDING_BLOCKS_NAME:
+					return CreativeTabs.tabBlock;
+				case Category.DECORATIONS_NAME:
+					return CreativeTabs.tabDecorations;
+				case Category.TECHNOLOGY_NAME:
+					return CreativeTabs.tabRedstone;
+				case Category.TRANSPORTATION_NAME:
+					return CreativeTabs.tabTransport;
+				case Category.FOOD_NAME:
+					return CreativeTabs.tabFood;
+				case Category.TOOLS_NAME:
+					return CreativeTabs.tabTools;
+				case Category.COMBAT_NAME:
+					return CreativeTabs.tabCombat;
+				case Category.ALCHEMY_NAME:
+					return CreativeTabs.tabBrewing;
+				case Category.MATERIALS_NAME:
+					return CreativeTabs.tabMaterials;
+				case Category.MISCELLANEOUS_NAME:
+					return CreativeTabs.tabMisc;
+			}
+		}
+		return Arrays.stream(CreativeTabs.creativeTabArray)
+			.filter(tab -> tab.getTabLabel().equals(category.name))
+			.findFirst()
+			.orElseGet(() -> new ModCreativeTab(category.name, category.item.map(ItemConverter.instance()::toNative).orElse(item)));
+	}
+}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
@@ -36,6 +36,7 @@ import nova.core.wrapper.mc.forge.v18.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v18.util.ModCreativeTab;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.backward.BWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
+import nova.core.wrapper.mc.forge.v18.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.FWItemBlock;
 import nova.internal.core.Game;
 
@@ -142,16 +143,7 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 		if (blockWrapper.dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {
 			//Add into creative tab
 			Category category = blockWrapper.dummy.components.get(Category.class);
-			Optional<CreativeTabs> first = Arrays.stream(CreativeTabs.creativeTabArray)
-				.filter(tab -> tab.getTabLabel().equals(category.name))
-				.findFirst();
-			if (first.isPresent()) {
-				blockWrapper.setCreativeTab(first.get());
-			} else {
-				Optional<nova.core.item.Item> item = category.item;
-				ModCreativeTab tab = new ModCreativeTab(category.name, item.isPresent() ? Game.natives().toNative(item.get()) : Item.getItemFromBlock(blockWrapper));
-				blockWrapper.setCreativeTab(tab);
-			}
+			blockWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, blockWrapper));
 		}
 
 		System.out.println("[NOVA]: Registered '" + blockFactory.getID() + "' block.");

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
@@ -20,8 +20,8 @@
 
 package nova.core.wrapper.mc.forge.v18.wrapper.item;
 
+import nova.core.wrapper.mc.forge.v18.wrapper.CategoryConverter;
 import com.google.common.collect.HashBiMap;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -208,16 +208,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, Loadable
 			if (dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {
 				//Add into creative tab
 				Category category = dummy.components.get(Category.class);
-				Optional<CreativeTabs> first = Arrays.stream(CreativeTabs.creativeTabArray)
-					.filter(tab -> tab.getTabLabel().equals(category.name))
-					.findFirst();
-				if (first.isPresent()) {
-					itemWrapper.setCreativeTab(first.get());
-				} else {
-					Optional<Item> item = category.item;
-					ModCreativeTab tab = new ModCreativeTab(category.name, item.isPresent() ? Game.natives().toNative(item.get()) : itemWrapper);
-					itemWrapper.setCreativeTab(tab);
-				}
+				itemWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, itemWrapper));
 			}
 
 			System.out.println("[NOVA]: Registered '" + itemFactory.getID() + "' item.");

--- a/src/main/java/nova/core/component/Category.java
+++ b/src/main/java/nova/core/component/Category.java
@@ -32,8 +32,58 @@ import java.util.Optional;
  */
 public class Category extends Component implements Identifiable {
 
+	/** Building blocks (ie. stone, dirt, bricks etc.) */
+	public static final String BUILDING_BLOCKS_NAME = "nova:building_blocks";
+	/** Building blocks (ie. stone, dirt, bricks etc.) */
+	public static final Category BUILDING_BLOCKS = new Category(BUILDING_BLOCKS_NAME);
+
+	/** Decorative blocks (ie. flower pots, curtains, torches etc.) */
+	public static final String DECORATIONS_NAME = "nova:decorations";
+	/** Decorative blocks (ie. flower pots, curtains, torches etc.) */
+	public static final Category DECORATIONS = new Category(DECORATIONS_NAME);
+
+	/** Technology (ie. buttons, levers, wires etc.) */
+	public static final String TECHNOLOGY_NAME = "nova:technology";
+	/** Technology (ie. buttons, levers, wires etc.) */
+	public static final Category TECHNOLOGY = new Category(TECHNOLOGY_NAME);
+
+	/** Transportation (ie. cars, rails, minecarts etc.) */
+	public static final String TRANSPORTATION_NAME = "nova:transportation";
+	/** Transportation (ie. cars, rails, minecarts etc.) */
+	public static final Category TRANSPORTATION = new Category(TRANSPORTATION_NAME);
+
+	/** Food (ie. bacon and other foods) */
+	public static final String FOOD_NAME = "nova:food";
+	/** Food (ie. bacon and other foods) */
+	public static final Category FOOD = new Category(FOOD_NAME);
+
+	/** Tools */
+	public static final String TOOLS_NAME = "nova:tools";
+	/** Tools */
+	public static final Category TOOLS = new Category(TOOLS_NAME);
+
+	/** Weapons and armor */
+	public static final String COMBAT_NAME = "nova:combat";
+	/** Weapons and armor */
+	public static final Category COMBAT = new Category(COMBAT_NAME);
+
+	/** Alchemy (ie. brewing ingredients, potions etc.) */
+	public static final String ALCHEMY_NAME = "nova:alchemy";
+	/** Alchemy (ie. brewing ingredients, potions etc.) */
+	public static final Category ALCHEMY = new Category(ALCHEMY_NAME);
+
+	/** Raw materials (ie. ingots etc.) */
+	public static final String MATERIALS_NAME = "nova:materials";
+	/** Raw materials (ie. ingots etc.) */
+	public static final Category MATERIALS = new Category(MATERIALS_NAME);
+
+	/** Miscellaneous items (ie. what doesn't fit into any other category) */
+	public static final String MISCELLANEOUS_NAME = "nova:miscellaneous";
+	/** Miscellaneous items (ie. what doesn't fit into any other category) */
+	public static final Category MISCELLANEOUS = new Category(MISCELLANEOUS_NAME);
+
 	public final String name;
-	public Optional<Item> item;
+	public final Optional<Item> item;
 
 	public Category(String name, Item item) {
 		this.name = name;
@@ -45,8 +95,26 @@ public class Category extends Component implements Identifiable {
 		this.item = Optional.empty();
 	}
 
+	public Category withItem(Optional<Item> item) {
+		return item.isPresent() ? new Category(name, item.get()) : new Category(name);
+	}
+
 	@Override
 	public String getID() {
 		return name;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 7;
+		hash = 31 * hash + this.name.hashCode();
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) return true;
+		if (other == null || getClass() != other.getClass()) return false;
+		return name.equals(((Category)other).name);
 	}
 }


### PR DESCRIPTION
This PR decouples categories from Minecraft.

Existing mods won’t be broken, but their categories won’t work outside Minecraft.