### PR TITLE
Make NOVA Wrappers load in the correct order

### DIFF
--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
@@ -85,6 +85,7 @@ public class NovaMinecraft {
 
 	private static Set<ForgeLoadable> nativeConverters;
 	private static Set<ForgeLoadable> novaWrappers = new HashSet<>();
+	private static List<ForgeLoadable> novaModWrappers;
 
 	public static void registerWrapper(ForgeLoadable wrapper) {
 		novaWrappers.add(wrapper);
@@ -157,6 +158,8 @@ public class NovaMinecraft {
 			ProgressManager.ProgressBar progressBar = ProgressManager.push("Loading NOVA mods", modClasses.isEmpty() ? 1 : modClasses.size());
 			launcher.load(new FMLProgressBar(progressBar));
 			ProgressManager.pop(progressBar);
+			novaModWrappers = launcher.getOrdererdMods().stream().filter(mod -> mod instanceof ForgeLoadable).map(mod -> (ForgeLoadable) mod).collect(Collectors.toList());
+			novaWrappers.removeAll(novaModWrappers);
 
 			/**
 			 * Instantiate native loaders
@@ -177,7 +180,17 @@ public class NovaMinecraft {
 			Game.entities().init();
 
 			//Load preInit
-			novaWrappers.stream().forEachOrdered(wrapper -> wrapper.preInit(evt));
+			progressBar = ProgressManager.push("Pre-initializing NOVA wrappers", (novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
+			FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
+			novaModWrappers.stream().forEachOrdered(wrapper -> {
+				fmlProgressBar.step(wrapper.getClass());
+				wrapper.preInit(evt);
+			});
+			novaWrappers.stream().forEachOrdered(wrapper -> {
+				fmlProgressBar.step(wrapper.getClass());
+				wrapper.preInit(evt);
+			});
+			ProgressManager.pop(progressBar);
 
 			proxy.preInit(evt);
 
@@ -199,7 +212,17 @@ public class NovaMinecraft {
 		try {
 			proxy.init(evt);
 			nativeConverters.stream().forEachOrdered(forgeLoadable -> forgeLoadable.init(evt));
-			novaWrappers.stream().forEachOrdered(wrapper -> wrapper.init(evt));
+			ProgressManager.ProgressBar progressBar = ProgressManager.push("Initializing NOVA wrappers", (novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
+			FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
+			novaModWrappers.stream().forEachOrdered(wrapper -> {
+				fmlProgressBar.step(wrapper.getClass());
+				wrapper.init(evt);
+			});
+			novaWrappers.stream().forEachOrdered(wrapper -> {
+				fmlProgressBar.step(wrapper.getClass());
+				wrapper.init(evt);
+			});
+			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
 			System.out.println("Error during init");
 			e.printStackTrace();
@@ -210,10 +233,20 @@ public class NovaMinecraft {
 	@Mod.EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
 		try {
-			Game.recipes().init();
 			proxy.postInit(evt);
 			nativeConverters.stream().forEachOrdered(forgeLoadable -> forgeLoadable.postInit(evt));
-			novaWrappers.stream().forEachOrdered(wrapper -> wrapper.postInit(evt));
+			Game.recipes().init();
+			ProgressManager.ProgressBar progressBar = ProgressManager.push("Post-initializing NOVA wrappers", (novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
+			FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
+			novaModWrappers.stream().forEachOrdered(wrapper -> {
+				fmlProgressBar.step(wrapper.getClass());
+				wrapper.postInit(evt);
+			});
+			novaWrappers.stream().forEachOrdered(wrapper -> {
+				fmlProgressBar.step(wrapper.getClass());
+				wrapper.postInit(evt);
+			});
+			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
 			System.out.println("Error during postInit");
 			e.printStackTrace();

--- a/src/main/java/nova/internal/core/launch/ModLoader.java
+++ b/src/main/java/nova/internal/core/launch/ModLoader.java
@@ -20,9 +20,7 @@
 
 package nova.internal.core.launch;
 
-import nova.core.loader.Mod;
 import nova.core.util.ProgressBar;
-import nova.internal.core.Game;
 import nova.internal.core.bootstrap.DependencyInjectionEntryPoint;
 
 import java.lang.annotation.Annotation;
@@ -30,6 +28,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -219,5 +218,9 @@ public class ModLoader<ANNOTATION extends Annotation> {
 
 	public Optional<ANNOTATION> getCurrentMod() {
 		return this.currentMod;
+	}
+
+	public List<Object> getOrdererdMods() {
+		return Collections.unmodifiableList(orderedMods);
 	}
 }


### PR DESCRIPTION
This PR makes the NOVA wrappers that have a `@Mod` annotation load in the order according to the `@Mod.dependencies()` parameter.
Should have been in #256.