### PR TITLE
Implement Sided Components

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ComponentInjector.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ComponentInjector.java
@@ -21,6 +21,7 @@
 package nova.core.wrapper.mc.forge.v17.asm.lib;
 
 import nova.core.component.Component;
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.Passthrough;
 import nova.core.network.NetworkTarget.Side;
@@ -60,7 +61,8 @@ public class ComponentInjector<T> implements Opcodes {
 		this.baseClazz = baseClazz;
 	}
 
-	public synchronized T inject(ComponentProvider provider, Class<?>[] typeArgs, Object[] args) {
+	@SuppressWarnings("rawtypes")
+	public synchronized T inject(ComponentProvider<? extends ComponentMap> provider, Class<?>[] typeArgs, Object[] args) {
 		try {
 			List<Component> components = provider.components().stream()
 				.filter(component -> component.getClass().getAnnotationsByType(Passthrough.class).length > 0)
@@ -89,6 +91,7 @@ public class ComponentInjector<T> implements Opcodes {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	private T inject(T instance, ComponentProvider provider) throws ReflectiveOperationException {
 		Field f = instance.getClass().getDeclaredField("$$_provider");
 		f.setAccessible(true);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ComponentInjector.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ComponentInjector.java
@@ -21,6 +21,7 @@
 package nova.core.wrapper.mc.forge.v18.asm.lib;
 
 import nova.core.component.Component;
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.Passthrough;
 import nova.core.network.NetworkTarget.Side;
@@ -60,7 +61,8 @@ public class ComponentInjector<T> implements Opcodes {
 		this.baseClazz = baseClazz;
 	}
 
-	public synchronized T inject(ComponentProvider provider, Class<?>[] typeArgs, Object[] args) {
+	@SuppressWarnings("rawtypes")
+	public synchronized T inject(ComponentProvider<? extends ComponentMap> provider, Class<?>[] typeArgs, Object[] args) {
 		try {
 			List<Component> components = provider.components().stream()
 				.filter(component -> component.getClass().getAnnotationsByType(Passthrough.class).length > 0)
@@ -89,6 +91,7 @@ public class ComponentInjector<T> implements Opcodes {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	private T inject(T instance, ComponentProvider provider) throws ReflectiveOperationException {
 		Field f = instance.getClass().getDeclaredField("$$_provider");
 		f.setAccessible(true);

--- a/src/main/java/nova/core/block/Block.java
+++ b/src/main/java/nova/core/block/Block.java
@@ -21,7 +21,7 @@
 package nova.core.block;
 
 import nova.core.block.component.BlockProperty;
-import nova.core.component.ComponentProvider;
+import nova.core.component.SidedComponentProvider;
 import nova.core.component.misc.FactoryProvider;
 import nova.core.component.transform.BlockTransform;
 import nova.core.entity.Entity;
@@ -43,7 +43,8 @@ import java.util.Set;
 /**
  * @author Calclavia
  */
-public class Block extends ComponentProvider implements Identifiable {
+@SuppressWarnings("rawtypes")
+public class Block extends SidedComponentProvider implements Identifiable {
 
 	public ItemFactory getItemFactory() {
 		return Game.items().getItemFromBlock(getFactory());

--- a/src/main/java/nova/core/block/component/BlockProperty.java
+++ b/src/main/java/nova/core/block/component/BlockProperty.java
@@ -3,6 +3,8 @@ package nova.core.block.component;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import nova.core.component.Component;
+import nova.core.component.SidedComponent;
+import nova.core.component.UnsidedComponent;
 import nova.core.sound.Sound;
 
 import java.util.Optional;
@@ -20,6 +22,7 @@ public interface BlockProperty {
 	 * The standard, regular block hardness is 1. {@code Double.POSITIVE_INFINITY} is unbreakable.
 	 * </p>
 	 */
+	@UnsidedComponent
 	public static class Hardness extends Component implements BlockProperty {
 		private double hardness = 1.0;
 
@@ -50,6 +53,7 @@ public interface BlockProperty {
 	 * The standard, regular block resistance is 1. {@link Double#POSITIVE_INFINITY} is unexplodable.
 	 * </p>
 	 */
+	@UnsidedComponent
 	public static class Resistance extends Component implements BlockProperty {
 		private double resistance = 1.0;
 
@@ -79,6 +83,7 @@ public interface BlockProperty {
 	 *
 	 * @author winsock
 	 */
+	@UnsidedComponent
 	public static class BlockSound extends Component implements BlockProperty {
 		public BiMap<BlockSoundTrigger, Sound> blockSoundSoundMap = HashBiMap.create();
 		public Optional<BiMap<String, Sound>> customDefinedSounds;
@@ -162,6 +167,7 @@ public interface BlockProperty {
 	 *
 	 * @author winsock
 	 */
+	@SidedComponent
 	public static class Opacity extends Component implements BlockProperty {
 		// TODO maybe consider a double for opacity? Where 0 is 100% transparent and 1 is 100% opaque?
 
@@ -196,6 +202,7 @@ public interface BlockProperty {
 //	/**
 //	 * Indicates whether the block is replaceable.
 //	 */
+//	@UnsidedComponent
 //	public static final class Replaceable extends Component implements BlockProperty {
 //		/**
 //		 * Singleton for Replaceable.

--- a/src/main/java/nova/core/block/component/Connectable.java
+++ b/src/main/java/nova/core/block/component/Connectable.java
@@ -19,6 +19,7 @@
  */package nova.core.block.component;
 
 import nova.core.component.Component;
+import nova.core.component.SidedComponent;
 import nova.core.event.bus.Event;
 import nova.core.event.bus.EventBus;
 
@@ -31,6 +32,7 @@ import java.util.function.Supplier;
  * A component that defines a connection with another.  C is the connector type
  * @author Calclavia
  */
+@SidedComponent
 public class Connectable<C> extends Component {
 
 	public final EventBus<Event> connectEvent = new EventBus<>();
@@ -42,12 +44,12 @@ public class Connectable<C> extends Component {
 
 	public Supplier<Set<C>> connections = Collections::emptySet;
 
-	public Connectable setCanConnect(Function<C, Boolean> canConnect) {
+	public Connectable<C> setCanConnect(Function<C, Boolean> canConnect) {
 		this.canConnect = canConnect;
 		return this;
 	}
 
-	public Connectable setConnections(Supplier<Set<C>> connections) {
+	public Connectable<C> setConnections(Supplier<Set<C>> connections) {
 		this.connections = connections;
 		return this;
 	}

--- a/src/main/java/nova/core/block/component/LightEmitter.java
+++ b/src/main/java/nova/core/block/component/LightEmitter.java
@@ -19,9 +19,11 @@
  */package nova.core.block.component;
 
 import nova.core.component.Component;
+import nova.core.component.SidedComponent;
 
 import java.util.function.Supplier;
 
+@SidedComponent
 public class LightEmitter extends Component {
 
 	/**

--- a/src/main/java/nova/core/component/Component.java
+++ b/src/main/java/nova/core/component/Component.java
@@ -30,9 +30,11 @@ import nova.core.util.Identifiable;
  */
 public abstract class Component implements Identifiable {
 
-	private ComponentProvider provider;
+	@SuppressWarnings("rawtypes")
+	private ComponentProvider<? extends ComponentMap> provider;
 
-	public ComponentProvider getProvider() {
+	@SuppressWarnings("rawtypes")
+	public ComponentProvider<? extends ComponentMap> getProvider() {
 		if (provider == null) {
 			throw new ComponentException("Component not bound to any ComponentProvider.", this);
 		}
@@ -40,7 +42,11 @@ public abstract class Component implements Identifiable {
 		return provider;
 	}
 
-	Component setProvider(ComponentProvider provider) {
+	@SuppressWarnings("rawtypes")
+	Component setProvider(ComponentProvider<? extends ComponentMap> provider) {
+		if (this.provider == provider)
+			return this;
+
 		this.provider = provider;
 		onProviderChange();
 		return this;

--- a/src/main/java/nova/core/component/ComponentMap.java
+++ b/src/main/java/nova/core/component/ComponentMap.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.core.component;
+
+import nova.core.component.ComponentProvider.ComponentAdded;
+import nova.core.component.ComponentProvider.ComponentRemoved;
+import nova.core.component.exception.ComponentException;
+import nova.internal.core.Game;
+import se.jbee.inject.Dependency;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A class that contains all components.
+ *
+ * @author Calclavia
+ */
+public class ComponentMap extends HashMap<Class<? extends Component>, Component> {
+	private static final long serialVersionUID = 2017_02_12L;
+
+	public final ComponentProvider<?> provider;
+
+	public ComponentMap(ComponentProvider<?> provider) {
+		this.provider = provider;
+	}
+
+	/**
+	 * Adds a new component based on its superclass or interface using dependency injection.
+	 * @param componentType The interface or abstract class associated with the new component.
+	 * @param <C> The node type.
+	 * @return A new node of N type.
+	 */
+	public final <C extends Component> C add(Class<C> componentType) {
+		return add(Game.injector().resolve(Dependency.dependency(componentType)));
+	}
+
+	/**
+	 * Adds a component to the provider.
+	 * @param component The component to add.
+	 * @return the component.
+	 * @throws ComponentException when the component already exists on the block.
+	 */
+	@SuppressWarnings("unchecked")
+	public final <C extends Component> C add(C component) {
+		if (has(component.getClass())) {
+			throw new ComponentException("Attempt to add two components of the type %s to " + this, component);
+		}
+
+		//Place component into component map
+		put(component.getClass(), component);
+
+		//Set component's provider.
+		component.setProvider(provider);
+
+		//Publish component add event
+		provider.events.publish(new ComponentAdded(component));
+		return component;
+	}
+
+	/**
+	 * Adds a component to the block if it is not present.
+	 * @param component The component to add.
+	 * @return the component.
+	 */
+	@SuppressWarnings("unchecked")
+	public final <C extends Component> C getOrAdd(C component) {
+		if (has(component.getClass())) {
+			return get((Class<C>) component.getClass());
+		}
+
+		return add(component);
+	}
+
+	/**
+	 * Checks if a component type exists in this provider.
+	 * @param componentType the component type to check.
+	 * @return true if the component exists on the provider.
+	 */
+	public final boolean has(Class<?> componentType) {
+		return keySet().stream().anyMatch(componentType::isAssignableFrom);
+	}
+
+	/**
+	 * Removes a component from the block.
+	 * @param component The component to remove.
+	 * @return the component removed.
+	 * @throws ComponentException when the component does not exist.
+	 */
+	public final <C extends Component> C remove(C component) {
+		//Remove component based on class
+		remove(component.getClass());
+
+		//Set provider on component to null
+		component.setProvider(null);
+
+		//Publish component event
+		provider.events.publish(new ComponentProvider.ComponentRemoved(component));
+		return component;
+	}
+
+	/**
+	 * Removes the component from the provider.
+	 * @param componentType the component type.
+	 * @return the component removed.
+	 * @throws ComponentException when the component does not exist.
+	 */
+	@SuppressWarnings("unchecked")
+	public final <C extends Component> C remove(Class<C> componentType) {
+		if (!has(componentType)) {
+			throw new ComponentException("Attempt to remove component that does not exist: %s", componentType);
+		}
+
+		C component = (C) super.remove(componentType);
+
+		//Set provider on component to null
+		component.setProvider(null);
+
+		//Publish component event
+		provider.events.publish(new ComponentProvider.ComponentRemoved(component));
+		return component;
+	}
+
+	/**
+	 * Gets an optional of the component with the specified type.
+	 * @param componentType the type to get.
+	 * @return the optional of the component found or {@code Optional.empty()}.
+	 * if the component was not found.
+	 */
+	@SuppressWarnings("unchecked")
+	public final <C> Optional<C> getOp(Class<C> componentType) {
+		if (componentType.isAssignableFrom(Component.class)) {
+			Component component = get(componentType.asSubclass(Component.class));
+			if (component != null) {
+				return Optional.of((C) component);
+			}
+		}
+
+		Set<C> collect = getSet(componentType);
+
+		if (collect.size() > 1) {
+			throw new ComponentException("Ambiguous component search. For component/interface %s there are multiple components found: %s", componentType, collect);
+		}
+
+		return collect.stream().findFirst();
+	}
+
+	/**
+	 * Gets the component with the specified type.
+	 * @param componentType the type to get.
+	 * @return the component.
+	 * @throws ComponentException if the component doesn't exist.
+	 */
+	public final <C> C get(Class<C> componentType) {
+		return getOp(componentType).orElseThrow(() -> new ComponentException("Attempt to get component that does not exist: %s", componentType));
+	}
+
+	/**
+	 * Gets the set of the components with the specified type.
+	 * @param componentType the type to get.
+	 * @return the set of the components.
+	 */
+	public final <C> Set<C> getSet(Class<C> componentType) {
+		return Collections.unmodifiableSet(values().stream()
+			.filter(c -> componentType.isAssignableFrom(c.getClass()))
+			.map(componentType::cast)
+			.collect(Collectors.toSet()));
+	}
+}

--- a/src/main/java/nova/core/component/ComponentProvider.java
+++ b/src/main/java/nova/core/component/ComponentProvider.java
@@ -20,18 +20,12 @@
 
 package nova.core.component;
 
-import nova.core.component.exception.ComponentException;
 import nova.core.event.bus.Event;
 import nova.core.event.bus.EventBus;
-import nova.internal.core.Game;
-import se.jbee.inject.Dependency;
 
+import java.lang.reflect.Constructor;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A component block provides the components associated with the object.
@@ -39,146 +33,29 @@ import java.util.stream.Collectors;
  * {@code ComponentProvider} is implemented in blocks or entities.
  * @author Calclavia
  */
-public abstract class ComponentProvider {
+@SuppressWarnings("rawtypes")
+public abstract class ComponentProvider<CM extends ComponentMap> {
 
 	public final EventBus<Event> events = new EventBus<>();
 
-	public final ComponentMap components = new ComponentMap();
+	public final CM components;
 
-	/**
-	 * A class that contains all components.
-	 */
-	public class ComponentMap extends HashMap<Class<? extends Component>, Component> {
-		/**
-		 * Adds a new component based on its superclass or interface using dependency injection.
-		 * @param theInterface The interface or abstract class associated with the new component
-		 * @param <C> The node type
-		 * @return A new node of N type.
-		 */
-		public final <C extends Component> C add(Class<C> theInterface) {
-			return add(Game.injector().resolve(Dependency.dependency(theInterface)));
-		}
+	@SuppressWarnings("unchecked")
+	public ComponentProvider() {
+		this(ComponentMap.class);
+	}
 
-		/**
-		 * Adds a component to the block.
-		 * @param component The component to add.
-		 * @return the component.
-		 * @throws ComponentException when the component already exists on the block.
-		 */
-		public final <C extends Component> C add(C component) {
-			if (has(component.getClass())) {
-				throw new ComponentException("Attempt to add two components of the type %s to " + this, component);
-			}
-
-			//Place component into component map
-			put(component.getClass(), component);
-
-			//Set component's provider.
-			component.setProvider(ComponentProvider.this);
-
-			//Publish component add event
-			events.publish(new ComponentAdded(component));
-			return component;
-		}
-
-		/**
-		 * Adds a component to the block if it is not present.
-		 * @param component The component to add.
-		 * @return the component.
-		 */
-		@SuppressWarnings("unchecked")
-		public final <C extends Component> C getOrAdd(C component) {
-			if (has(component.getClass())) {
-				return get((Class<C>) component.getClass());
-			}
-
-			return add(component);
-		}
-
-		/**
-		 * Removes a component from the block.
-		 * @param component The component to remove
-		 * @return the component removed.
-		 */
-		public final <C extends Component> C remove(C component) {
-			//Remove component based on class
-			remove(component.getClass());
-
-			//Set provider on component to null
-			component.setProvider(null);
-
-			//Publish component event
-			events.publish(new ComponentRemoved(component));
-			return component;
-		}
-
-		/**
-		 * Checks if a component type exists in this provider.
-		 * @param componentType the component type to check.
-		 * @return true if the component exists on the block.
-		 */
-		public final boolean has(Class<?> componentType) {
-			return keySet().stream()
-				.anyMatch(componentType::isAssignableFrom);
-		}
-
-		/**
-		 * Removes the component from the block.
-		 * @param componentType the component type.
-		 * @return the component removed.
-		 * @throws ComponentException when the component dies not exist.
-		 */
-		@SuppressWarnings("unchecked")
-		public final <C extends Component> C remove(Class<C> componentType) {
-			if (!has(componentType)) {
-				throw new ComponentException("Attempt to remove component that does not exist: %s", componentType);
-			}
-
-			C component = (C) super.remove(componentType);
-
-			//Set provider on component to null
-			component.setProvider(null);
-
-			//Publish component event
-			events.publish(new ComponentRemoved(component));
-			return component;
-		}
-
-		/**
-		 * Gets an optional of the component with the specified type.
-		 * @param componentType the type to get.
-		 * @return the optional of the component found or {@code Optional.empty()}
-		 * if the component was not found.
-		 */
-		@SuppressWarnings("unchecked")
-		public final <C> Optional<C> getOp(Class<C> componentType) {
-			if (componentType.isAssignableFrom(Component.class)) {
-				Component component = get(componentType.asSubclass(Component.class));
-				if (component != null) {
-					return Optional.of((C) component);
-				}
-			}
-
-			Set<C> collect = values().stream()
-				.filter(c -> componentType.isAssignableFrom(c.getClass()))
-				.map(componentType::cast)
-				.collect(Collectors.toSet());
-
-			if (collect.size() > 1) {
-				throw new ComponentException("Ambiguous component search. For component/interface %s there are multiple components found: %s", componentType, collect);
-			}
-
-			return collect.stream().findFirst();
-		}
-
-		/**
-		 * Gets the component with the specified type.
-		 * @param componentType the type to get.
-		 * @return the component.
-		 * @throws ComponentException if the component doesn't exist.
-		 */
-		public final <C> C get(Class<C> componentType) {
-			return getOp(componentType).orElseThrow(() -> new ComponentException("Attempt to get component that does not exist: %s", componentType));
+	@SuppressWarnings("unchecked")
+	public <C extends ComponentMap> ComponentProvider(Class<C> componentsClass) {
+		try {
+			// TODO Figure out how to dependency injection with this without it crashing
+			Class<CM> clazz = ((Class) componentsClass);
+			Constructor<CM> constructor = clazz.getDeclaredConstructor(ComponentProvider.class);
+			constructor.setAccessible(true);
+			this.components = constructor.newInstance(this);
+			constructor.setAccessible(false);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalArgumentException(e);
 		}
 	}
 
@@ -186,6 +63,7 @@ public abstract class ComponentProvider {
 	 * Gets a set of components that this ComponentProvider provides.
 	 * @return A set of components.
 	 */
+	@SuppressWarnings("unchecked")
 	public final Collection<Component> components() {
 		return new HashSet<>(components.values());
 	}

--- a/src/main/java/nova/core/component/SidedComponent.java
+++ b/src/main/java/nova/core/component/SidedComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 NOVA, All rights reserved.
+ * Copyright (c) 2017 NOVA, All rights reserved.
  * This library is free software, licensed under GNU Lesser General Public License version 3
  *
  * This file is part of NOVA.
@@ -18,16 +18,23 @@
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package nova.core.component.transform;
+package nova.core.component;
 
-import nova.core.component.UnsidedComponent;
-import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * A 3D block transform.
- * @author Calclavia
+ * Specifies that this component type is sided.
+ *
+ * Components don't need to have this annotation to be sided.
+ * A component can't declare both this annotation and {@link UnsidedComponent}.
+ *
+ * @author ExE Boss
  */
-@UnsidedComponent
-public class BlockTransform extends WorldTransform<Vector3D> {
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SidedComponent {
 
 }

--- a/src/main/java/nova/core/component/SidedComponentMap.java
+++ b/src/main/java/nova/core/component/SidedComponentMap.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.core.component;
+
+import nova.core.component.exception.ComponentException;
+import nova.core.util.Direction;
+import nova.internal.core.Game;
+import se.jbee.inject.Dependency;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A class that contains all sided components.
+ * @author ExE Boss
+ */
+public class SidedComponentMap extends ComponentMap {
+	private static final long serialVersionUID = 2017_02_12L;
+
+	public final ComponentMap up = new ComponentMap(provider);
+	public final ComponentMap down = new ComponentMap(provider);
+
+	public final ComponentMap north = new ComponentMap(provider);
+	public final ComponentMap south = new ComponentMap(provider);
+
+	public final ComponentMap west = new ComponentMap(provider);
+	public final ComponentMap east = new ComponentMap(provider);
+
+	public SidedComponentMap(ComponentProvider<?> provider) {
+		super(provider);
+	}
+
+	public final Map<Direction, ComponentMap> getComponentsForDirections() {
+		return Arrays.stream(Direction.values()).collect(Collectors.toMap(Function.identity(), this::getComponents));
+	}
+
+	public final ComponentMap getComponents(Direction direction) {
+		switch (direction) {
+			case UP:
+				return up;
+			case DOWN:
+				return down;
+
+			case NORTH:
+				return north;
+			case SOUTH:
+				return south;
+
+			case WEST:
+				return west;
+			case EAST:
+				return east;
+
+			default:
+				return this;
+		}
+	}
+
+	/**
+	 * Adds a new component based on its superclass or interface using dependency injection.
+	 * @param direction The direction to add the component to.
+	 * @param componentType The interface or abstract class associated with the new component.
+	 * @param <C> The node type.
+	 * @return A new node of N type.
+	 */
+	public final <C extends Component> C add(Class<C> componentType, Direction direction) {
+		return getComponents(direction).add(ensureValid(componentType, direction));
+	}
+
+	/**
+	 * Adds a new component based on its superclass or interface using dependency injection.
+	 * @param directions The directions to add the component to.
+	 * @param componentType The interface or abstract class associated with the new component.
+	 * @param <C> The node type.
+	 * @return A new node of N type.
+	 */
+	public final <C extends Component> C add(Class<C> componentType, Direction... directions) {
+		return this.add(Game.injector().resolve(Dependency.dependency(ensureValid(componentType, directions))), directions);
+	}
+
+	/**
+	 * Adds a component to the provider.
+	 * @param direction The direction to add the component to.
+	 * @param component The component to add.
+	 * @return the component.
+	 * @throws ComponentException when the component already exists on the block.
+	 */
+	public final <C extends Component> C add(C component, Direction direction) {
+		return getComponents(direction).add(ensureValid(component, direction));
+	}
+
+	/**
+	 * Adds a component to the provider.
+	 * @param component The component to add.
+	 * @param directions The directions to add the component to.
+	 * @return the component.
+	 * @throws ComponentException when the component already exists on the block.
+	 */
+	public final <C extends Component> C add(C component, Direction... directions) {
+		for (Direction direction : directions)
+			return getComponents(direction).add(ensureValid(component, direction));
+		return component;
+	}
+
+	/**
+	 * Adds a component to the block if it is not present.
+	 * @param component The component to add.
+	 * @param direction The direction to get or add the component to.
+	 * @return the component.
+	 */
+	public final <C extends Component> C getOrAdd(C component, Direction direction) {
+		return getComponents(direction).getOrAdd(component);
+	}
+
+	/**
+	 * Checks if a component type exists in this provider.
+	 * @param componentType the component type to check.
+	 * @param direction The direction to check.
+	 * @return true if the component exists on the provider.
+	 */
+	public final boolean has(Class<?> componentType, Direction direction) {
+		return getComponents(direction).has(componentType) || this.has(componentType);
+	}
+
+	/**
+	 * Checks if a component type can be removed from this provider.
+	 * @param componentType the component type to check.
+	 * @param direction The direction to check.
+	 * @return true if the component exists on the provider.
+	 */
+	public final boolean canRemove(Class<?> componentType, Direction direction) {
+		return getComponents(direction).has(componentType);
+	}
+
+	/**
+	 * Removes the component from the block.
+	 * @param component the component type.
+	 * @param direction The direction to remove the component from.
+	 * @return the component removed.
+	 * @throws ComponentException when the component does not exist.
+	 */
+	public final <C extends Component> C remove(C component, Direction direction) {
+		return getComponents(direction).remove(component);
+	}
+
+	/**
+	 * Removes the component from the provider.
+	 * @param componentType the component type.
+	 * @param direction The direction to remove the component from.
+	 * @return the component removed.
+	 * @throws ComponentException when the component does not exist.
+	 */
+	@SuppressWarnings("unchecked")
+	public final <C extends Component> C remove(Class<C> componentType, Direction direction) {
+		return getComponents(direction).remove(componentType);
+	}
+
+	/**
+	 * Gets an optional of the component with the specified type.
+	 * @param componentType the type to get.
+	 * @param direction The direction to get the component from.
+	 * @return the optional of the component found or {@code Optional.empty()}.
+	 * if the component was not found.
+	 */
+	@SuppressWarnings("unchecked")
+	public final <C> Optional<C> getOp(Class<C> componentType, Direction direction) {
+		Optional<C> c = getComponents(direction).getOp(componentType);
+		if (!c.isPresent())
+			c = this.getOp(componentType);
+		return c;
+	}
+
+	/**
+	 * Gets the component with the specified type.
+	 * @param componentType the type to get.
+	 * @param direction The direction to get the component from.
+	 * @return the component.
+	 * @throws ComponentException if the component doesn't exist.
+	 */
+	public final <C> C get(Class<C> componentType, Direction direction) {
+		return getComponents(direction).getOp(componentType).orElseGet(() -> this.get(componentType));
+	}
+
+	/**
+	 * Gets the set of the components with the specified type.
+	 * @param componentType the type to get.
+	 * @param direction The direction to get the component from.
+	 * @return the set of the components.
+	 */
+	public final <C> Set<C> getSet(Class<C> componentType, Direction direction) {
+		Set<C> c = new HashSet<>(getComponents(direction).getSet(componentType));
+		c.addAll(this.getSet(componentType));
+		return c;
+	}
+
+	private <C extends Component> C ensureValid(C component, Direction... directions) {
+		for (Direction direction : directions)
+			ensureValid(component, direction);
+		return component;
+	}
+
+	private <C extends Component> C ensureValid(C component, Direction direction) {
+		ensureValid(component.getClass(), direction);
+		return component;
+	}
+
+	private <C extends Component> Class<C> ensureValid(Class<C> componentType, Direction... directions) {
+		for (Direction direction : directions)
+			ensureValid(componentType, direction);
+		return componentType;
+	}
+
+	private <C extends Component> Class<C> ensureValid(Class<C> componentType, Direction direction) {
+		if (getComponents(direction) == this)
+			return componentType;
+
+		if (componentType.isAnnotationPresent(UnsidedComponent.class))
+			throw new IllegalArgumentException("Unsided components can't be added to a specific side");
+
+		return componentType;
+	}
+}

--- a/src/main/java/nova/core/component/SidedComponentProvider.java
+++ b/src/main/java/nova/core/component/SidedComponentProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nova.core.component;
+
+import nova.core.util.Direction;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @author ExE Boss
+ */
+@SuppressWarnings("rawtypes")
+public abstract class SidedComponentProvider extends ComponentProvider<SidedComponentMap> {
+
+	@SuppressWarnings("unchecked")
+	public SidedComponentProvider() {
+		super(SidedComponentMap.class);
+	}
+
+	public final Collection<Component> unsidedComponents() {
+		return components();
+	}
+
+	public final Map<Direction, Collection<Component>> sidedComponents() {
+		return Arrays.stream(Direction.values()).collect(Collectors.toMap(Function.identity(), d -> new HashSet<>(components.getComponents(d).values())));
+	}
+}

--- a/src/main/java/nova/core/component/UnsidedComponent.java
+++ b/src/main/java/nova/core/component/UnsidedComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 NOVA, All rights reserved.
+ * Copyright (c) 2017 NOVA, All rights reserved.
  * This library is free software, licensed under GNU Lesser General Public License version 3
  *
  * This file is part of NOVA.
@@ -18,16 +18,23 @@
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package nova.core.component.transform;
+package nova.core.component;
 
-import nova.core.component.UnsidedComponent;
-import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * A 3D block transform.
- * @author Calclavia
+ * Specifies that this component type is not sided.
+ *
+ * Components must have this annotation to be unsided.
+ * A component can't declare both this annotation and {@link SidedComponent}.
+ *
+ * @author ExE Boss
  */
-@UnsidedComponent
-public class BlockTransform extends WorldTransform<Vector3D> {
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UnsidedComponent {
 
 }

--- a/src/main/java/nova/core/component/misc/Collider.java
+++ b/src/main/java/nova/core/component/misc/Collider.java
@@ -26,6 +26,7 @@ package nova.core.component.misc;
 
 import nova.core.component.Component;
 import nova.core.component.ComponentProvider;
+import nova.core.component.UnsidedComponent;
 import nova.core.entity.Entity;
 import nova.core.event.bus.Event;
 import nova.core.util.shape.Cuboid;
@@ -37,6 +38,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+@UnsidedComponent
 public class Collider extends Component {
 	public final ComponentProvider provider;
 

--- a/src/main/java/nova/core/component/misc/Damageable.java
+++ b/src/main/java/nova/core/component/misc/Damageable.java
@@ -21,12 +21,14 @@
 package nova.core.component.misc;
 
 import nova.core.component.Component;
+import nova.core.component.UnsidedComponent;
 import nova.core.util.Identifiable;
 
 /**
  * Applied to objects that can take damage.
  * @author Calclavia
  */
+@UnsidedComponent
 public abstract class Damageable extends Component {
 
 	public void damage(double amount) {

--- a/src/main/java/nova/core/component/misc/FactoryProvider.java
+++ b/src/main/java/nova/core/component/misc/FactoryProvider.java
@@ -1,12 +1,14 @@
 package nova.core.component.misc;
 
 import nova.core.component.Component;
+import nova.core.component.UnsidedComponent;
 import nova.core.util.registry.Factory;
 
 /**
  * Provides a reference to the factory that created this object
  * @author Calclavia
  */
+@UnsidedComponent
 public class FactoryProvider extends Component {
 	public final Factory<?, ?> factory;
 

--- a/src/main/java/nova/core/component/renderer/DynamicRenderer.java
+++ b/src/main/java/nova/core/component/renderer/DynamicRenderer.java
@@ -21,6 +21,7 @@
 package nova.core.component.renderer;
 
 import nova.core.component.ComponentProvider;
+import nova.core.component.UnsidedComponent;
 import nova.core.render.pipeline.RenderPipeline;
 
 /**
@@ -30,6 +31,7 @@ import nova.core.render.pipeline.RenderPipeline;
  *
  * @see StaticRenderer
  */
+@UnsidedComponent
 public class DynamicRenderer extends Renderer {
 
 }

--- a/src/main/java/nova/core/component/renderer/Renderer.java
+++ b/src/main/java/nova/core/component/renderer/Renderer.java
@@ -21,6 +21,7 @@
 package nova.core.component.renderer;
 
 import nova.core.component.Component;
+import nova.core.component.UnsidedComponent;
 import nova.core.render.model.Model;
 
 import java.util.function.Consumer;
@@ -28,6 +29,7 @@ import java.util.function.Consumer;
 /**
  * @author Calclavia
  */
+@UnsidedComponent
 public abstract class Renderer extends Component {
 	/**
 	 * Called to render.

--- a/src/main/java/nova/core/component/renderer/StaticRenderer.java
+++ b/src/main/java/nova/core/component/renderer/StaticRenderer.java
@@ -21,6 +21,7 @@
 package nova.core.component.renderer;
 
 import nova.core.component.ComponentProvider;
+import nova.core.component.UnsidedComponent;
 import nova.core.render.pipeline.RenderPipeline;
 
 /**
@@ -30,6 +31,7 @@ import nova.core.render.pipeline.RenderPipeline;
  *
  * @see DynamicRenderer
  */
+@UnsidedComponent
 public class StaticRenderer extends Renderer {
 
 }

--- a/src/main/java/nova/core/component/transform/EntityTransform.java
+++ b/src/main/java/nova/core/component/transform/EntityTransform.java
@@ -20,6 +20,7 @@
 
 package nova.core.component.transform;
 
+import nova.core.component.UnsidedComponent;
 import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
@@ -29,6 +30,7 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
  * Note that the implemented Transform3d for entities require a constructor with type ComponentProvider.
  * @author Calclavia
  */
+@UnsidedComponent
 public class EntityTransform extends WorldTransform<Vector3D> {
 
 	//The rotation of the transform. Can never be null.

--- a/src/main/java/nova/core/component/transform/Orientation.java
+++ b/src/main/java/nova/core/component/transform/Orientation.java
@@ -23,7 +23,9 @@ package nova.core.component.transform;
 import nova.core.block.Block;
 import nova.core.block.Stateful;
 import nova.core.component.Component;
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
+import nova.core.component.UnsidedComponent;
 import nova.core.entity.Entity;
 import nova.core.entity.component.Living;
 import nova.core.event.bus.Event;
@@ -46,9 +48,11 @@ import java.util.Optional;
  * A component that is applied to providers with discrete orientations.
  * @author Calclavia
  */
+@UnsidedComponent
 public class Orientation extends Component implements Storable, Stateful, Syncable {
 
-	public final ComponentProvider provider;
+	@SuppressWarnings("rawtypes")
+	public final ComponentProvider<? extends ComponentMap> provider;
 
 	/**
 	 * The allowed rotation directions the block can face.
@@ -65,6 +69,7 @@ public class Orientation extends Component implements Storable, Stateful, Syncab
 	/**
 	 * @param provider The block to apply discrete orientations to
 	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public Orientation(ComponentProvider provider) {
 		this.provider = provider;
 	}
@@ -193,7 +198,7 @@ public class Orientation extends Component implements Storable, Stateful, Syncab
 		if (provider instanceof Block) {
 			Vector3D position = entity.position();
 			if (FastMath.abs(position.getX() - ((Block) provider).x()) < 2.0F && FastMath.abs(position.getZ() - ((Block) provider).z()) < 2.0F) {
-				double height = position.add(entity.components.get(Living.class).faceDisplacement.get()).getY();
+				double height = position.add(entity.components.getOp(Living.class).map(l -> l.faceDisplacement.get()).orElse(Vector3D.ZERO)).getY();
 
 				if (height - ((Block) provider).y() > 2.0D) {
 					return Direction.fromOrdinal(1);

--- a/src/main/java/nova/core/component/transform/PositionTransform.java
+++ b/src/main/java/nova/core/component/transform/PositionTransform.java
@@ -21,11 +21,13 @@
 package nova.core.component.transform;
 
 import nova.core.component.Component;
+import nova.core.component.UnsidedComponent;
 
 /**
  * A tansform that is associates with a position.
  * @author Calclavia
  */
+@UnsidedComponent
 public class PositionTransform<P> extends Component {
 
 	private P position;

--- a/src/main/java/nova/core/component/transform/WorldTransform.java
+++ b/src/main/java/nova/core/component/transform/WorldTransform.java
@@ -20,12 +20,14 @@
 
 package nova.core.component.transform;
 
+import nova.core.component.UnsidedComponent;
 import nova.core.world.World;
 
 /**
  * A transform that is linked with a world.
  * @author Calclavia
  */
+@UnsidedComponent
 public class WorldTransform<P> extends PositionTransform<P> {
 
 	private World world;

--- a/src/main/java/nova/core/entity/Entity.java
+++ b/src/main/java/nova/core/entity/Entity.java
@@ -21,6 +21,7 @@
 package nova.core.entity;
 
 import nova.core.block.Stateful;
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.misc.FactoryProvider;
 import nova.core.component.transform.EntityTransform;
@@ -33,7 +34,8 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 /**
  * An entity is an object in the world that has a position.
  */
-public class Entity extends ComponentProvider implements UniqueIdentifiable, Identifiable, Stateful {
+@SuppressWarnings("rawtypes")
+public class Entity extends ComponentProvider<ComponentMap> implements UniqueIdentifiable, Identifiable, Stateful {
 
 	public final EntityTransform transform() {
 		return components.get(EntityTransform.class);

--- a/src/main/java/nova/core/entity/component/Living.java
+++ b/src/main/java/nova/core/entity/component/Living.java
@@ -19,6 +19,7 @@
  */package nova.core.entity.component;
 
 import nova.core.component.Component;
+import nova.core.component.UnsidedComponent;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.function.Supplier;
@@ -27,6 +28,7 @@ import java.util.function.Supplier;
  * For entities that are alive.
  * @author Calclavia
  */
+@UnsidedComponent
 public class Living extends Component {
 
 	/**

--- a/src/main/java/nova/core/entity/component/Player.java
+++ b/src/main/java/nova/core/entity/component/Player.java
@@ -20,12 +20,14 @@
 
 package nova.core.entity.component;
 
+import nova.core.component.UnsidedComponent;
 import nova.core.component.inventory.InventoryPlayer;
 import nova.core.entity.Entity;
 
 /**
  * Basic representation of Player
  */
+@UnsidedComponent
 public abstract class Player extends Living {
 	/**
 	 * @return Returns player name that can be used to identify this player

--- a/src/main/java/nova/core/entity/component/RigidBody.java
+++ b/src/main/java/nova/core/entity/component/RigidBody.java
@@ -21,6 +21,7 @@
 package nova.core.entity.component;
 
 import nova.core.component.Component;
+import nova.core.component.UnsidedComponent;
 import nova.core.component.Updater;
 import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -29,6 +30,7 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
  * A rigid body component for entity physics.
  * @author Calclavia
  */
+@UnsidedComponent
 public abstract class RigidBody extends Component implements Updater {
 	/**
 	 * Mass in kilograms. Default is 1 kg.

--- a/src/main/java/nova/core/item/Item.java
+++ b/src/main/java/nova/core/item/Item.java
@@ -20,6 +20,7 @@
 
 package nova.core.item;
 
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.misc.FactoryProvider;
 import nova.core.entity.Entity;
@@ -34,7 +35,8 @@ import java.util.List;
 import java.util.Optional;
 
 //TODO: This Storable implementation is flawed and not based on ID.
-public class Item extends ComponentProvider implements Identifiable, Storable {
+@SuppressWarnings("rawtypes")
+public class Item extends ComponentProvider<ComponentMap> implements Identifiable, Storable, Cloneable {
 
 	/**
 	 * The amount of this item that is present.

--- a/src/main/java/nova/core/render/pipeline/BlockRenderPipeline.java
+++ b/src/main/java/nova/core/render/pipeline/BlockRenderPipeline.java
@@ -20,6 +20,7 @@
 
 package nova.core.render.pipeline;
 
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.misc.Collider;
 import nova.core.render.Color;
@@ -44,7 +45,8 @@ import java.util.function.Supplier;
  */
 public class BlockRenderPipeline extends RenderPipeline {
 
-	public final ComponentProvider componentProvider;
+	@SuppressWarnings("rawtypes")
+	public final ComponentProvider<? extends ComponentMap> componentProvider;
 
 	/**
 	 * Called to get the texture of this block for a certain side.
@@ -75,9 +77,10 @@ public class BlockRenderPipeline extends RenderPipeline {
 	 */
 	public Function<Direction, Color> colorMultiplier = (dir) -> Color.white;
 
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public BlockRenderPipeline(ComponentProvider componentProvider) {
 		this.componentProvider = componentProvider;
-		bounds = () -> componentProvider.components.getOp(Collider.class).map(c -> c.boundingBox.get()).orElse(Cuboid.ONE);
+		bounds = () -> this.componentProvider.components.getOp(Collider.class).map(c -> c.boundingBox.get()).orElse(Cuboid.ONE);
 		consumer = model -> model.addChild(draw(new MeshModel()));
 	}
 

--- a/src/main/java/nova/core/util/RayTracer.java
+++ b/src/main/java/nova/core/util/RayTracer.java
@@ -16,9 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
- */package nova.core.util;
+ */
+
+package nova.core.util;
 
 import nova.core.block.Block;
+import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.misc.Collider;
 import nova.core.component.transform.WorldTransform;
@@ -58,7 +61,7 @@ public class RayTracer {
 	 * @param entity The entity
 	 */
 	public RayTracer(Entity entity) {
-		this(new Ray(entity.position().add(entity.components.has(Living.class) ? entity.components.get(Living.class).faceDisplacement.get() : Vector3D.ZERO), entity.rotation().applyTo(Vector3DUtil.FORWARD)));
+		this(new Ray(entity.position().add(entity.components.getOp(Living.class).map(l -> l.faceDisplacement.get()).orElse(Vector3D.ZERO)), entity.rotation().applyTo(Vector3DUtil.FORWARD)));
 	}
 
 	/**
@@ -135,7 +138,8 @@ public class RayTracer {
 				.sorted();
 	}
 
-	public <R extends RayTraceResult> Stream<R> rayTraceCollider(ComponentProvider colliderProvider, BiFunction<Vector3D, Cuboid, R> resultMapper) {
+	@SuppressWarnings("rawtypes")
+	public <R extends RayTraceResult> Stream<R> rayTraceCollider(ComponentProvider<? extends ComponentMap> colliderProvider, BiFunction<Vector3D, Cuboid, R> resultMapper) {
 		return
 			colliderProvider.components.get(Collider.class)
 				.occlusionBoxes


### PR DESCRIPTION
This PR implements sided components. This allows for Blocks to have specific components on one side only.
Required for Minecraft 1.9+ wrappers for compatibility with Forge’s Capabilities.