### PR TITLE
Allow mods to unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ shadowJar {
 }
 
 task wrapperTestJar(type: Jar) {
+	from(sourceSets.main.output) {
+		include "nova/internal/core/launch/**"
+	}
 	from(sourceSets.test.output) {
 		include "nova/wrappertests/**"
 		include "nova/testutils/**"


### PR DESCRIPTION
This PR is supposed to work with https://github.com/NOVA-Team/NOVA-Gradle/pull/13 to add `NovaLauncher` to the `wrappertests` jar to allow mods to unit test.