### PR TITLE
Make NOVA Wrappers load in the correct order (1.8)

### DIFF
--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
@@ -190,6 +190,7 @@ public class NovaMinecraft {
 				fmlProgressBar.step(wrapper.getClass());
 				wrapper.preInit(evt);
 			});
+			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 
 			proxy.preInit(evt);
@@ -222,6 +223,7 @@ public class NovaMinecraft {
 				fmlProgressBar.step(wrapper.getClass());
 				wrapper.init(evt);
 			});
+			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
 			System.out.println("Error during init");
@@ -246,6 +248,7 @@ public class NovaMinecraft {
 				fmlProgressBar.step(wrapper.getClass());
 				wrapper.postInit(evt);
 			});
+			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
 			System.out.println("Error during postInit");


### PR DESCRIPTION
Contains a bug fix for a crash bug that I also accidentally forgot to commit from #257 and #266.