### PR TITLE
Allow Factory to use dependency injection for instantiating objects

### DIFF
--- a/src/main/java/nova/core/block/BlockFactory.java
+++ b/src/main/java/nova/core/block/BlockFactory.java
@@ -27,6 +27,7 @@ import nova.core.language.Translateable;
 import nova.core.util.registry.Factory;
 import nova.internal.core.Game;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -40,12 +41,111 @@ public class BlockFactory extends Factory<BlockFactory, Block> implements Transl
 	final Consumer<BlockFactory> postRegister;
 	private String unlocalizedName;
 
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @param processor The function applied to the block after construction
+	 * @param postRegister Function for registering item blocks
+	 * @param mapping The custom DI mapping
+	 */
+	public BlockFactory(String id, Class<? extends Block> type, Function<Block, Block> processor, Consumer<BlockFactory> postRegister, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, processor, mapping);
+		this.postRegister = postRegister;
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
+
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @param processor The function applied to the block after construction
+	 * @param postRegister Function for registering item blocks
+	 */
+	public BlockFactory(String id, Class<? extends Block> type, Function<Block, Block> processor, Consumer<BlockFactory> postRegister) {
+		super(id, type, processor);
+		this.postRegister = postRegister;
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
+
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @param mapping The custom DI mapping
+	 */
+	public BlockFactory(String id, Class<? extends Block> type, Function<Class<?>, Optional<?>> mapping) {
+		this(id, type, blockFactory -> Game.items().register(id, () -> new ItemBlock(blockFactory)), mapping);
+	}
+
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param type The class of the block
+	 */
+	public BlockFactory(String id, Class<? extends Block> type) {
+		this(id, type, blockFactory -> {Game.items().register(id, () -> new ItemBlock(blockFactory));});
+	}
+
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @param postRegister Function for registering item blocks
+	 * @param mapping The custom DI mapping
+	 */
+	public BlockFactory(String id, Class<? extends Block> type, Consumer<BlockFactory> postRegister, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, block -> block, mapping);
+		this.postRegister = postRegister;
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
+
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @param postRegister Function for registering item blocks
+	 */
+	public BlockFactory(String id, Class<? extends Block> type, Consumer<BlockFactory> postRegister) {
+		super(id, type);
+		this.postRegister = postRegister;
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
+
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param constructor The constructor function
+	 * @param processor The function applied to the block after construction
+	 * @param postRegister Function for registering item blocks
+	 */
 	public BlockFactory(String id, Supplier<Block> constructor, Function<Block, Block> processor, Consumer<BlockFactory> postRegister) {
 		super(id, constructor, processor);
 		this.postRegister = postRegister;
 		this.setUnlocalizedName(getID().replaceAll(":", "."));
 	}
 
+	/**
+	 * Initializes a BlockFactory. A specific implementation of item block generation
+	 * may be provided by post create.
+	 *
+	 * @param id The block ID
+	 * @param constructor The constructor function
+	 */
 	public BlockFactory(String id, Supplier<Block> constructor) {
 		this(id, constructor, blockFactory -> Game.items().register(id, () -> new ItemBlock(blockFactory)));
 	}
@@ -53,6 +153,8 @@ public class BlockFactory extends Factory<BlockFactory, Block> implements Transl
 	/**
 	 * Initializes a BlockFactory. A specific implementation of item block generation
 	 * may be provided by post create.
+	 *
+	 * @param id The block ID
 	 * @param constructor The constructor function
 	 * @param postRegister Function for registering item blocks
 	 */

--- a/src/main/java/nova/core/block/BlockManager.java
+++ b/src/main/java/nova/core/block/BlockManager.java
@@ -25,6 +25,8 @@ import nova.core.util.registry.FactoryManager;
 import nova.core.util.registry.Registry;
 import nova.internal.core.Game;
 
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class BlockManager extends FactoryManager<BlockManager, Block, BlockFactory> {
@@ -43,8 +45,32 @@ public class BlockManager extends FactoryManager<BlockManager, Block, BlockFacto
 
 	/**
 	 * Register a new block with custom constructor arguments.
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @param mapping The custom DI mapping
+	 * @return The block factory
+	 */
+	@Override
+	public BlockFactory register(String id, Class<? extends Block> type, Function<Class<?>, Optional<?>> mapping) {
+		return register(new BlockFactory(id, type, mapping));
+	}
+
+	/**
+	 * Register a new block with custom constructor arguments.
+	 * @param id The block ID
+	 * @param type The class of the block
+	 * @return The block factory
+	 */
+	@Override
+	public BlockFactory register(String id, Class<? extends Block> type) {
+		return register(new BlockFactory(id, type));
+	}
+
+	/**
+	 * Register a new block with custom constructor arguments.
+	 * @param id The block ID
 	 * @param constructor Block instance {@link Supplier}
-	 * @return Dummy block
+	 * @return The block factory
 	 */
 	@Override
 	public BlockFactory register(String id, Supplier<Block> constructor) {

--- a/src/main/java/nova/core/component/ComponentProvider.java
+++ b/src/main/java/nova/core/component/ComponentProvider.java
@@ -22,10 +22,12 @@ package nova.core.component;
 
 import nova.core.event.bus.Event;
 import nova.core.event.bus.EventBus;
+import nova.internal.core.util.InjectionUtil;
 
 import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 
 /**
  * A component block provides the components associated with the object.
@@ -47,16 +49,8 @@ public abstract class ComponentProvider<CM extends ComponentMap> {
 
 	@SuppressWarnings("unchecked")
 	public <C extends ComponentMap> ComponentProvider(Class<C> componentsClass) {
-		try {
-			// TODO Figure out how to dependency injection with this without it crashing
-			Class<CM> clazz = ((Class) componentsClass);
-			Constructor<CM> constructor = clazz.getDeclaredConstructor(ComponentProvider.class);
-			constructor.setAccessible(true);
-			this.components = constructor.newInstance(this);
-			constructor.setAccessible(false);
-		} catch (ReflectiveOperationException e) {
-			throw new IllegalArgumentException(e);
-		}
+		this.components = (CM) InjectionUtil.newInstance(componentsClass,
+			clazz -> ComponentProvider.class == clazz ? Optional.of(this) : Optional.empty());
 	}
 
 	/**

--- a/src/main/java/nova/core/component/fluid/FluidFactory.java
+++ b/src/main/java/nova/core/component/fluid/FluidFactory.java
@@ -22,6 +22,7 @@ package nova.core.component.fluid;
 
 import nova.core.util.registry.Factory;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -29,6 +30,18 @@ import java.util.function.Supplier;
  * @author Calclavia
  */
 public class FluidFactory extends Factory<FluidFactory, Fluid> {
+
+	public FluidFactory(String id, Class<? extends Fluid> type, Function<Fluid, Fluid> processor, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, processor, mapping);
+	}
+
+	public FluidFactory(String id, Class<? extends Fluid> type, Function<Fluid, Fluid> processor) {
+		super(id, type, processor);
+	}
+
+	public FluidFactory(String id, Class<? extends Fluid> type) {
+		super(id, type);
+	}
 
 	public FluidFactory(String id, Supplier<Fluid> constructor, Function<Fluid, Fluid> processor) {
 		super(id, constructor, processor);

--- a/src/main/java/nova/core/component/fluid/FluidManager.java
+++ b/src/main/java/nova/core/component/fluid/FluidManager.java
@@ -23,6 +23,8 @@ package nova.core.component.fluid;
 import nova.core.util.registry.FactoryManager;
 import nova.core.util.registry.Registry;
 
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class FluidManager extends FactoryManager<FluidManager, Fluid, FluidFactory> {
@@ -34,6 +36,16 @@ public class FluidManager extends FactoryManager<FluidManager, Fluid, FluidFacto
 		//TODO: Too Minecraft specific. Implementation should be hidden.
 		this.water = register("water", Fluid::new);
 		this.lava = register("lava", Fluid::new);
+	}
+
+	@Override
+	public FluidFactory register(String id, Class<? extends Fluid> type, Function<Class<?>, Optional<?>> mapping) {
+		return register(new FluidFactory(id, type, fluid -> fluid, mapping));
+	}
+
+	@Override
+	public FluidFactory register(String id, Class<? extends Fluid> type) {
+		return register(new FluidFactory(id, type));
 	}
 
 	@Override

--- a/src/main/java/nova/core/entity/EntityFactory.java
+++ b/src/main/java/nova/core/entity/EntityFactory.java
@@ -21,8 +21,11 @@
 package nova.core.entity;
 
 import nova.core.component.misc.FactoryProvider;
+import nova.core.retention.Data;
+import nova.core.retention.Storable;
 import nova.core.util.registry.Factory;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -31,6 +34,19 @@ import java.util.function.Supplier;
  * @author Calclavia
  */
 public class EntityFactory extends Factory<EntityFactory, Entity> {
+
+	public EntityFactory(String id, Class<? extends Entity> type, Function<Entity, Entity> processor, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, processor, mapping);
+	}
+
+	public EntityFactory(String id, Class<? extends Entity> type, Function<Entity, Entity> processor) {
+		super(id, type, processor);
+	}
+
+	public EntityFactory(String id, Class<? extends Entity> type) {
+		super(id, type);
+	}
+
 	public EntityFactory(String id, Supplier<Entity> constructor, Function<Entity, Entity> processor) {
 		super(id, constructor, processor);
 	}

--- a/src/main/java/nova/core/entity/EntityManager.java
+++ b/src/main/java/nova/core/entity/EntityManager.java
@@ -24,6 +24,8 @@ import nova.core.util.registry.FactoryManager;
 import nova.core.util.registry.Registry;
 import nova.internal.core.Game;
 
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class EntityManager extends FactoryManager<EntityManager, Entity, EntityFactory> {
@@ -34,7 +36,31 @@ public class EntityManager extends FactoryManager<EntityManager, Entity, EntityF
 
 	/**
 	 * Register a new entity type.
-	 * @param constructor The lambda expression to create a new constructor.
+	 * @param id The entity ID
+	 * @param type The class of the entity
+	 * @param mapping The custom DI mapping
+	 * @return The entity factory
+	 */
+	@Override
+	public EntityFactory register(String id, Class<? extends Entity> type, Function<Class<?>, Optional<?>> mapping) {
+		return register(new EntityFactory(id, type, entity -> entity, mapping));
+	}
+
+	/**
+	 * Register a new entity type.
+	 * @param id The entity ID
+	 * @param type The class of the block
+	 * @return The entity factory
+	 */
+	@Override
+	public EntityFactory register(String id, Class<? extends Entity> type) {
+		return register(new EntityFactory(id, type));
+	}
+
+	/**
+	 * Register a new entity type.
+	 * @param id The entity ID
+	 * @param constructor Entity instance {@link Supplier}
 	 * @return The entity factory
 	 */
 	@Override

--- a/src/main/java/nova/core/item/ItemFactory.java
+++ b/src/main/java/nova/core/item/ItemFactory.java
@@ -28,6 +28,7 @@ import nova.core.retention.Storable;
 import nova.core.util.Identifiable;
 import nova.core.util.registry.Factory;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -36,6 +37,21 @@ import java.util.function.Supplier;
  */
 public class ItemFactory extends Factory<ItemFactory, Item> implements Identifiable, Translateable {
 	private String unlocalizedName;
+
+	public ItemFactory(String id, Class<? extends Item> type, Function<Item, Item> processor, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, processor, mapping);
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
+
+	public ItemFactory(String id, Class<? extends Item> type, Function<Item, Item> processor) {
+		super(id, type, processor);
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
+
+	public ItemFactory(String id, Class<? extends Item> type) {
+		super(id, type);
+		this.setUnlocalizedName(getID().replaceAll(":", "."));
+	}
 
 	public ItemFactory(String id, Supplier<Item> constructor, Function<Item, Item> processor) {
 		super(id, constructor, processor);

--- a/src/main/java/nova/core/item/ItemManager.java
+++ b/src/main/java/nova/core/item/ItemManager.java
@@ -28,6 +28,7 @@ import nova.core.util.registry.Registry;
 import nova.internal.core.Game;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class ItemManager extends FactoryManager<ItemManager, Item, ItemFactory> {
@@ -41,8 +42,32 @@ public class ItemManager extends FactoryManager<ItemManager, Item, ItemFactory> 
 
 	/**
 	 * Register a new item with custom constructor arguments.
-	 * @param constructor The lambda expression to create a new constructor.
-	 * @return Dummy item
+	 * @param id The item ID
+	 * @param type The class of the item
+	 * @param mapping The custom DI mapping
+	 * @return The item factory
+	 */
+	@Override
+	public ItemFactory register(String id, Class<? extends Item> type, Function<Class<?>, Optional<?>> mapping) {
+		return register(new ItemFactory(id, type, item -> item, mapping));
+	}
+
+	/**
+	 * Register a new item with custom constructor arguments.
+	 * @param id The item ID
+	 * @param type The class of the item
+	 * @return The item factory
+	 */
+	@Override
+	public ItemFactory register(String id, Class<? extends Item> type) {
+		return register(new ItemFactory(id, type));
+	}
+
+	/**
+	 * Register a new item with custom constructor arguments.
+	 * @param id The item ID
+	 * @param constructor Item instance {@link Supplier}
+	 * @return The item factory
 	 */
 	@Override
 	public ItemFactory register(String id, Supplier<Item> constructor) {

--- a/src/main/java/nova/core/util/registry/FactoryManager.java
+++ b/src/main/java/nova/core/util/registry/FactoryManager.java
@@ -23,6 +23,7 @@ package nova.core.util.registry;
 import nova.core.util.Identifiable;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -40,7 +41,29 @@ public abstract class FactoryManager<S extends FactoryManager<S, T, F>, T extend
 	/**
 	 * Register a new object construction factory.
 	 *
+	 * Note that you make use: register(id, BlockStone.class), passing the class of the implementation.
+	 * @param id The ID of the factory
+	 * @param mapping The custom DI mapping
+	 * @param type The class containing the implementation
+	 * @return The factory
+	 */
+	public abstract F register(String id, Class<? extends T> type, Function<Class<?>, Optional<?>> mapping);
+
+	/**
+	 * Register a new object construction factory.
+	 *
+	 * Note that you make use: register(id, BlockStone.class), passing the class of the implementation.
+	 * @param id The ID of the factory
+	 * @param type The class containing the implementation
+	 * @return The factory
+	 */
+	public abstract F register(String id, Class<? extends T> type);
+
+	/**
+	 * Register a new object construction factory.
+	 *
 	 * Note that you make use: register(BlockStone::new), passing a method reference.
+	 * @param id The ID of the factory
 	 * @param constructor Instance supplier {@link Supplier}
 	 * @return The factory
 	 */

--- a/src/main/java/nova/core/world/WorldFactory.java
+++ b/src/main/java/nova/core/world/WorldFactory.java
@@ -22,6 +22,7 @@ package nova.core.world;
 
 import nova.core.util.registry.Factory;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -30,6 +31,19 @@ import java.util.function.Supplier;
  * @author Calclavia
  */
 public class WorldFactory extends Factory<WorldFactory, World> {
+
+	public WorldFactory(String id, Class<? extends World> type, Function<World, World> processor, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, processor, mapping);
+	}
+
+	public WorldFactory(String id, Class<? extends World> type, Function<World, World> processor) {
+		super(id, type, processor);
+	}
+
+	public WorldFactory(String id, Class<? extends World> type) {
+		super(id, type);
+	}
+
 	public WorldFactory(String id, Supplier<World> constructor, Function<World, World> processor) {
 		super(id, constructor, processor);
 	}

--- a/src/main/java/nova/core/world/WorldManager.java
+++ b/src/main/java/nova/core/world/WorldManager.java
@@ -29,6 +29,7 @@ import nova.internal.core.Game;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class WorldManager extends FactoryManager<WorldManager, World, WorldFactory> {
@@ -45,6 +46,16 @@ public class WorldManager extends FactoryManager<WorldManager, World, WorldFacto
 		//Bind events
 		events.on(WorldEvent.Load.class).bind(evt -> sidedWorlds().add(evt.world));
 		events.on(WorldEvent.Unload.class).bind(evt -> sidedWorlds().remove(evt.world));
+	}
+
+	@Override
+	public WorldFactory register(String id, Class<? extends World> type, Function<Class<?>, Optional<?>> mapping) {
+		return register(new WorldFactory(id, type, world -> world, mapping));
+	}
+
+	@Override
+	public WorldFactory register(String id, Class<? extends World> type) {
+		return register(new WorldFactory(id, type));
 	}
 
 	@Override

--- a/src/main/java/nova/internal/core/util/InjectionUtil.java
+++ b/src/main/java/nova/internal/core/util/InjectionUtil.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.internal.core.util;
+
+import nova.internal.core.Game;
+import se.jbee.inject.Dependency;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class for easy Dependency Injection usage.
+ *
+ * @author Calclavia, ExE Boss
+ */
+public class InjectionUtil {
+
+	private InjectionUtil() {}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @return A new instance of the class or an empty {@link Optional}
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> Optional<T> newInstanceOp(Class<T> classToConstruct) {
+		return newInstanceOp(classToConstruct, true);
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param printStackTrace If the stack trace should be printed in full
+	 * @return A new instance of the class or an empty {@link Optional}
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> Optional<T> newInstanceOp(Class<T> classToConstruct, boolean printStackTrace) {
+		return newInstanceOp(classToConstruct, printStackTrace, clazz -> Optional.empty());
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param mapping Custom DI mapping
+	 * @return A new instance of the class or an empty {@link Optional}
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> Optional<T> newInstanceOp(Class<T> classToConstruct, Function<Class<?>, Optional<?>> mapping) {
+		return newInstanceOp(classToConstruct, true, mapping);
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param printStackTrace If the stack trace should be printed in full
+	 * @param mapping Custom DI mapping
+	 * @return A new instance of the class or an empty {@link Optional}
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> Optional<T> newInstanceOp(Class<T> classToConstruct, boolean printStackTrace, Function<Class<?>, Optional<?>> mapping) {
+		try {
+			return Optional.of(newInstanceOrThrow(classToConstruct, mapping));
+		} catch (Exception ex) {
+			if (printStackTrace)
+				ex.printStackTrace();
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @return A new instance of the class
+	 * @throws ExceptionInInitializerError If an exception is thrown
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> T newInstance(Class<T> classToConstruct) {
+		return newInstance(classToConstruct, true);
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param printStackTrace If the stack trace should be printed in full
+	 * @return A new instance of the class
+	 * @throws ExceptionInInitializerError If an exception is thrown
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> T newInstance(Class<T> classToConstruct, boolean printStackTrace) {
+		return newInstance(classToConstruct, printStackTrace, clazz -> Optional.empty());
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param mapping Custom DI mapping
+	 * @return A new instance of the class
+	 * @throws ExceptionInInitializerError If an exception is thrown
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> T newInstance(Class<T> classToConstruct, Function<Class<?>, Optional<?>> mapping) {
+		return newInstance(classToConstruct, true, mapping);
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param printStackTrace If the stack trace should be printed in full
+	 * @param mapping Custom DI mapping
+	 * @return A new instance of the class
+	 * @throws ExceptionInInitializerError If an exception is thrown
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	public static <T> T newInstance(Class<T> classToConstruct, boolean printStackTrace, Function<Class<?>, Optional<?>> mapping) {
+		try {
+			return newInstanceOrThrow(classToConstruct, mapping);
+		} catch (Exception ex) {
+			if (printStackTrace)
+				ex.printStackTrace();
+			ExceptionInInitializerError e = new ExceptionInInitializerError("Could not instantiate " + classToConstruct);
+			e.addSuppressed(ex);
+			throw e;
+		}
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @return A new instance of the class
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 * @throws InvocationTargetException
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T newInstanceOrThrow(Class<T> classToConstruct) throws InstantiationException, IllegalAccessException, InvocationTargetException {
+		return newInstanceOrThrow(classToConstruct, clazz -> Optional.empty());
+	}
+
+	/**
+	 * Attempt to construct the required class using Dependency Injection.
+	 *
+	 * Used by {@link nova.internal.core.launch.ModLoader#load(nova.core.util.ProgressBar, boolean) ModLoader.load()}
+	 *
+	 * @param <T> The object type
+	 * @param classToConstruct The class to construct
+	 * @param mapping Custom DI mapping
+	 * @return A new instance of the class
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 * @throws InvocationTargetException
+	 * @see Constructor#newInstance(java.lang.Object...)
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T newInstanceOrThrow(Class<T> classToConstruct, Function<Class<?>, Optional<?>> mapping) throws InstantiationException, IllegalAccessException, InvocationTargetException {
+		//get constructor with most parameters.
+		Constructor<?> cons = Arrays.stream(classToConstruct.getConstructors())
+			.max(Comparator.comparingInt((constructor) -> constructor.getParameterTypes().length)).get();
+
+		Object[] parameters = Arrays.stream(cons.getParameterTypes())
+			.map(clazz -> ((Optional<Object>) mapping.apply(clazz)).orElseGet(() -> Game.injector().resolve(Dependency.dependency(clazz))))
+			.collect(Collectors.toList()).toArray();
+
+		try {
+			cons.setAccessible(true);
+			return (T) cons.newInstance(parameters);
+		} finally {
+			cons.setAccessible(false);
+		}
+	}
+
+}


### PR DESCRIPTION
This PR implements `nova.internal.core.InjectionUtil` to allow usage of dependency injection when passing a class instead of a supplier to a Factory constructor.
This also fixes the dependency injection issue from #261, which prevented the usage of dependency injection back then.
`InjectionUtil` is now also used by `nova.internal.core.launch.ModLoader`