### PR TITLE
FW rendering fixes

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
@@ -97,11 +97,11 @@ public class BWBlock extends Block implements Storable {
 					.map(cuboid -> cuboid.subtract(pos))
 					.collect(Collectors.toSet());
 			});
+		//TODO: Set selection bounds
 		components.add(new StaticRenderer())
 			.onRender(model -> model.addChild(new CustomModel(self -> RenderBlocks.getInstance().renderStandardBlock(mcBlock, x(), y(), z()))));
 		WrapperEvent.BWBlockCreate event = new WrapperEvent.BWBlockCreate(world, pos, this, mcBlock);
 		Game.events().publish(event);
-		//TODO: Set selection bounds
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
@@ -424,22 +424,14 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 
 	@SideOnly(Side.CLIENT)
 	@Override
-	public void renderInventoryBlock(net.minecraft.block.Block block, int metadata, int modelId, RenderBlocks renderer) {
+	public void renderInventoryBlock(net.minecraft.block.Block block, int metadata, int modelId, RenderBlocks renderBlocks) {
 		if (this.dummy.components.has(Renderer.class)) {
 			GL11.glPushAttrib(GL_TEXTURE_BIT);
 			GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 			GL11.glPushMatrix();
 			Tessellator.instance.startDrawingQuads();
 			BWModel model = new BWModel();
-
-			if (this.dummy.components.has(StaticRenderer.class)) {
-				StaticRenderer staticRenderer = this.dummy.components.get(StaticRenderer.class);
-				staticRenderer.onRender.accept(model);
-			} else if (this.dummy.components.has(DynamicRenderer.class)) {
-				DynamicRenderer dynamicRenderer = this.dummy.components.get(DynamicRenderer.class);
-				dynamicRenderer.onRender.accept(model);
-			}
-
+			this.dummy.components.getSet(Renderer.class).forEach(renderer -> renderer.onRender.accept(model));
 			model.render();
 			Tessellator.instance.draw();
 			GL11.glPopMatrix();
@@ -449,14 +441,14 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 
 	@SideOnly(Side.CLIENT)
 	@Override
-	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, net.minecraft.block.Block block, int modelId, RenderBlocks renderer) {
+	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, net.minecraft.block.Block block, int modelId, RenderBlocks renderBlocks) {
 		Block blockInstance = getBlockInstance(world, new Vector3D(x, y, z));
-		Optional<StaticRenderer> opRenderer = blockInstance.components.getOp(StaticRenderer.class);
-		if (opRenderer.isPresent()) {
+		Optional<StaticRenderer> staticRenderer = blockInstance.components.getOp(StaticRenderer.class);
+		if (staticRenderer.isPresent()) {
 			BWModel model = new BWModel();
 			model.matrix = new MatrixStack().translate(x + 0.5, y + 0.5, z + 0.5);
-			opRenderer.get().onRender.accept(model);
-			model.renderWorld(world);
+			staticRenderer.get().onRender.accept(model);
+			model.render(world);
 
 			return Tessellator.instance.rawBufferIndex != 0; // Returns true if Tesselator is not empty. Avoids crash on empty Tesselator buffer.
 		}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
@@ -20,6 +20,7 @@
 
 package nova.core.wrapper.mc.forge.v17.wrapper.item;
 
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -36,9 +37,13 @@ import nova.core.wrapper.mc.forge.v17.wrapper.entity.backward.BWEntity;
 import nova.core.wrapper.mc.forge.v17.wrapper.render.BWModel;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 
 import java.util.List;
 import java.util.Optional;
+
+import static org.lwjgl.opengl.GL11.GL_TEXTURE_BIT;
 
 /**
  * An interface implemented by ItemBlockWrapper and ItemWrapper classes to override Minecraft's item events.
@@ -89,19 +94,29 @@ public interface ItemWrapperMethods extends IItemRenderer {
 	@Override
 	default void renderItem(IItemRenderer.ItemRenderType type, ItemStack itemStack, Object... data) {
 		Item item = Game.natives().toNova(itemStack);
-		BWModel model = new BWModel();
+		if (item.components.has(Renderer.class)) {
+			GL11.glPushAttrib(GL_TEXTURE_BIT);
+			GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+			GL11.glPushMatrix();
+			Tessellator.instance.startDrawingQuads();
+			BWModel model = new BWModel();
+			model.matrix.rotate(Direction.UP.toVector(), 1 / 4 * Math.PI);
+			model.matrix.rotate(Direction.EAST.toVector(), 1 / 6 * Math.PI);
+			model.matrix.scale(1.6, 1.6, 1.6);
 
-		if (item.components.has(StaticRenderer.class)) {
-			StaticRenderer staticRenderer = item.components.get(StaticRenderer.class);
-			staticRenderer.onRender.accept(model);
-		} else if (item.components.has(DynamicRenderer.class)) {
-			DynamicRenderer dynamicRenderer = item.components.get(DynamicRenderer.class);
-			dynamicRenderer.onRender.accept(model);
+			if (item.components.has(StaticRenderer.class)) {
+				StaticRenderer staticRenderer = item.components.get(StaticRenderer.class);
+				staticRenderer.onRender.accept(model);
+			} else if (item.components.has(DynamicRenderer.class)) {
+				DynamicRenderer dynamicRenderer = item.components.get(DynamicRenderer.class);
+				dynamicRenderer.onRender.accept(model);
+			}
+
+			model.render();
+			Tessellator.instance.draw();
+			GL11.glPopMatrix();
+			GL11.glPopAttrib();
 		}
-
-		// For some reason calling model.faces.size() returns 0.
-		// Yet staticRenderer.onRender.accept(model) still gets executed.
-		model.render();
 	}
 
 	default int getColorFromItemStack(ItemStack itemStack, int p_82790_2_) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
@@ -103,15 +103,7 @@ public interface ItemWrapperMethods extends IItemRenderer {
 			model.matrix.rotate(Direction.UP.toVector(), 1 / 4 * Math.PI);
 			model.matrix.rotate(Direction.EAST.toVector(), 1 / 6 * Math.PI);
 			model.matrix.scale(1.6, 1.6, 1.6);
-
-			if (item.components.has(StaticRenderer.class)) {
-				StaticRenderer staticRenderer = item.components.get(StaticRenderer.class);
-				staticRenderer.onRender.accept(model);
-			} else if (item.components.has(DynamicRenderer.class)) {
-				DynamicRenderer dynamicRenderer = item.components.get(DynamicRenderer.class);
-				dynamicRenderer.onRender.accept(model);
-			}
-
+			item.components.getSet(Renderer.class).forEach(r -> r.onRender.accept(model));
 			model.render();
 			Tessellator.instance.draw();
 			GL11.glPopMatrix();

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/render/BWModel.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/render/BWModel.java
@@ -67,8 +67,7 @@ public class BWModel extends MeshModel {
 			model -> {
 				if (model instanceof MeshModel) {
 					MeshModel meshModel = (MeshModel) model;
-					meshModel.faces.forEach(face ->
-					{
+					meshModel.faces.forEach(face -> {
 						// Brightness is defined as: skyLight << 20 | blockLight << 4
 						if (face.getBrightness() >= 0) {
 							tessellator.setBrightness((int) (face.getBrightness() * (15 << 20 | 11 << 4)));
@@ -80,15 +79,15 @@ public class BWModel extends MeshModel {
 
 							// TODO: Add Ambient Occlusion
 						/*
-						int aoBrightnessXYNN = block.getMixedBrightnessForBlock(blockAccess, translation.getX() - 1, translation.getY(), translation.zi());
-						int aoBrightnessYZNN = block.getMixedBrightnessForBlock(blockAccess, translation.getX(), translation.getY(), translation.zi() - 1);
-						int aoBrightnessYZNP = block.getMixedBrightnessForBlock(blockAccess, translation.getX(), translation.getY(), translation.zi() + 1);
-						int aoBrightnessXYPN = block.getMixedBrightnessForBlock(blockAccess, translation.getX() + 1, translation.getY(), translation.zi());
+						int aoBrightnessXYNN = block.getMixedBrightnessForBlock(access.get(), (int) nearestPos.getX() - 1, (int) nearestPos.getY(), (int) nearestPos.getZ());
+						int aoBrightnessYZNN = block.getMixedBrightnessForBlock(access.get(), (int) nearestPos.getX(), (int) nearestPos.getY(), (int) nearestPos.getZ() - 1);
+						int aoBrightnessYZNP = block.getMixedBrightnessForBlock(access.get(), (int) nearestPos.getX(), (int) nearestPos.getY(), (int) nearestPos.getZ() + 1);
+						int aoBrightnessXYPN = block.getMixedBrightnessForBlock(access.get(), (int) nearestPos.getX() + 1, (int) nearestPos.getY(), (int) nearestPos.getZ());
 
-						int brightnessTopLeft = getAoBrightness(aoBrightnessXYZNNP, this.aoBrightnessXYNN, this.aoBrightnessYZNP, i1);
-						int brightnessTopRight = getAoBrightness(aoBrightnessYZNP, this.aoBrightnessXYZPNP, this.aoBrightnessXYPN, i1);
-						int brightnessBottomRight = getAoBrightness(this.aoBrightnessYZNN, this.aoBrightnessXYPN, this.aoBrightnessXYZPNN, i1);
-						int brightnessBottomLeft = getAoBrightness(this.aoBrightnessXYNN, this.aoBrightnessXYZNNN, this.aoBrightnessYZNN, i1);
+						int brightnessTopLeft = getAoBrightness(aoBrightnessXYZNNP, aoBrightnessXYNN, aoBrightnessYZNP, i1);
+						int brightnessTopRight = getAoBrightness(aoBrightnessYZNP, aoBrightnessXYZPNP, aoBrightnessXYPN, i1);
+						int brightnessBottomRight = getAoBrightness(aoBrightnessYZNN, aoBrightnessXYPN, aoBrightnessXYZPNN, i1);
+						int brightnessBottomLeft = getAoBrightness(aoBrightnessXYNN, aoBrightnessXYZNNN, aoBrightnessYZNN, i1);
 						*/
 
 							tessellator.setBrightness(brightness);
@@ -98,7 +97,7 @@ public class BWModel extends MeshModel {
 							tessellator.setBrightness(15 << 20 | 11 << 4);
 						}
 
-						tessellator.setNormal((int) face.normal.getX(), (int) face.normal.getY(), (int) face.normal.getZ());
+						tessellator.setNormal((float) face.normal.getX(), (float) face.normal.getY(), (float) face.normal.getZ());
 
 						if (face.texture.isPresent()) {
 							if (entityRenderManager.isPresent() && face.texture.get() instanceof EntityTexture) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/render/BWModel.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/render/BWModel.java
@@ -44,7 +44,7 @@ public class BWModel extends MeshModel {
 	/**
 	 * Completes this rendering for a block.
 	 */
-	public void renderWorld(IBlockAccess blockAccess) {
+	public void render(IBlockAccess blockAccess) {
 		render(Optional.of(blockAccess), Optional.empty());
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/render/RenderUtility.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/render/RenderUtility.java
@@ -46,6 +46,7 @@ import nova.core.wrapper.mc.forge.v18.launcher.ForgeLoadable;
 import nova.core.wrapper.mc.forge.v18.wrapper.assets.AssetConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.FWItem;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemWrapperMethods;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.FWEmptyModel;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.FWSmartBlockModel;
@@ -79,30 +80,6 @@ public class RenderUtility implements ForgeLoadable {
 	public static final ResourceLocation particleResource = new ResourceLocation("textures/particle/particles.png");
 
 	public static final RenderUtility instance = new RenderUtility();
-	// Cruft needed to generate default item models
-	protected static final ItemModelGenerator ITEM_MODEL_GENERATOR = new ItemModelGenerator();
-	protected static final FaceBakery FACE_BAKERY = new FaceBakery();
-	// Ugly D:
-	protected static final ModelBlock MODEL_GENERATED = ModelBlock.deserialize(
-		"{\"" +
-			"elements\":[{" +
-			"  \"from\": [0, 0, 0], " +
-			"  \"to\": [16, 16, 16], " +
-			"  \"faces\": {" +
-			"      \"down\": {\"uv\": [0, 0, 16, 16], \"texture\":\"\"}" +
-			"  }}]," +
-			"  \"display\": {\n" +
-			"      \"thirdperson\": {\n" +
-			"          \"rotation\": [ -90, 0, 0 ],\n" +
-			"          \"translation\": [ 0, 1, -3 ],\n" +
-			"          \"scale\": [ 0.55, 0.55, 0.55 ]\n" +
-			"      },\n" +
-			"      \"firstperson\": {\n" +
-			"          \"rotation\": [ 0, -135, 25 ],\n" +
-			"          \"translation\": [ 0, 4, 2 ],\n" +
-			"          \"scale\": [ 1.7, 1.7, 1.7 ]\n" +
-			"      }\n" +
-			"}}");
 	//NOVA Texture to MC TextureAtlasSprite
 	private final HashMap<Texture, TextureAtlasSprite> textureMap = new HashMap<>();
 
@@ -232,20 +209,13 @@ public class RenderUtility implements ForgeLoadable {
 
 		//Register all items
 		Game.items().registry.forEach(itemFactory -> {
-			Object stackObj = Game.natives().toNative(itemFactory.build());
-			if (stackObj instanceof ItemStack) {
-				Item itemObj = ((ItemStack) stackObj).getItem();
-				if (itemObj instanceof FWItem) {
-					FWItem item = (FWItem) itemObj;
-					ResourceLocation objRL = (ResourceLocation) Item.itemRegistry.getNameForObject(item);
-					ModelResourceLocation itemLocation = new ModelResourceLocation(objRL, "inventory");
-
-					nova.core.item.Item dummy = item.getItemFactory().build();
-
-					if (dummy.components.has(Renderer.class)) {
-						event.modelRegistry.putObject(itemLocation, new FWSmartItemModel(dummy));
-					}
-				}
+			ItemStack stack = ItemConverter.instance().toNative(itemFactory);
+			Item itemObj = stack.getItem();
+			if (itemObj instanceof FWItem) {
+				FWItem item = (FWItem) itemObj;
+				ResourceLocation objRL = (ResourceLocation) Item.itemRegistry.getNameForObject(item);
+				ModelResourceLocation itemLocation = new ModelResourceLocation(objRL, "inventory");
+				event.modelRegistry.putObject(itemLocation, new FWSmartItemModel(item.getItemFactory().build()));
 			}
 		});
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/render/RenderUtility.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/render/RenderUtility.java
@@ -40,11 +40,13 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import nova.core.component.renderer.Renderer;
 import nova.core.component.renderer.StaticRenderer;
+import nova.core.item.ItemFactory;
 import nova.core.render.texture.Texture;
 import nova.core.wrapper.mc.forge.v18.launcher.ForgeLoadable;
 import nova.core.wrapper.mc.forge.v18.wrapper.assets.AssetConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.FWItem;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemWrapperMethods;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.FWEmptyModel;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.FWSmartBlockModel;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.FWSmartItemModel;
@@ -217,12 +219,14 @@ public class RenderUtility implements ForgeLoadable {
 				ResourceLocation itemRL = (ResourceLocation) Item.itemRegistry.getNameForObject(itemFromBlock);
 				ModelResourceLocation blockLocation = new ModelResourceLocation(blockRL, "normal");
 				ModelResourceLocation itemLocation = new ModelResourceLocation(itemRL, "inventory");
+				ItemFactory itemFactory = ((ItemWrapperMethods)itemFromBlock).getItemFactory();
+				nova.core.item.Item dummy = itemFactory.build();
 				if (block.dummy.components.has(StaticRenderer.class)) {
-					event.modelRegistry.putObject(blockLocation, new FWSmartBlockModel(block.dummy, true));
+					event.modelRegistry.putObject(blockLocation, new FWSmartBlockModel(block.dummy));
 				} else {
 					event.modelRegistry.putObject(blockLocation, new FWEmptyModel());
 				}
-				event.modelRegistry.putObject(itemLocation, new FWSmartBlockModel(block.dummy, true));
+				event.modelRegistry.putObject(itemLocation, new FWSmartBlockModel(block.dummy, dummy));
 			}
 		});
 
@@ -246,6 +250,7 @@ public class RenderUtility implements ForgeLoadable {
 		});
 	}
 
+	@Override
 	public void preInit(FMLPreInitializationEvent event) {
 		//Load models
 		Game.render().modelProviders.forEach(m -> {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
@@ -97,9 +97,9 @@ public class BWBlock extends Block implements Storable {
 					.map(cuboid -> cuboid.subtract(pos))
 					.collect(Collectors.toSet());
 			});
+		//TODO: Set selection bounds
 		WrapperEvent.BWBlockCreate event = new WrapperEvent.BWBlockCreate(world, pos, this, mcBlock);
 		Game.events().publish(event);
-		//TODO: Set selection bounds
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/BWModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/BWModel.java
@@ -24,6 +24,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.world.IBlockAccess;
 import nova.core.render.model.CustomModel;
 import nova.core.render.model.MeshModel;
 import nova.core.render.texture.EntityTexture;
@@ -39,11 +40,22 @@ import java.util.Optional;
  */
 public class BWModel extends MeshModel {
 
+	/**
+	 * Completes this rendering for a block.
+	 */
+	public void render(IBlockAccess blockAccess) {
+		render(Optional.of(blockAccess), Optional.empty());
+	}
+
 	public void render() {
-		render(Optional.empty());
+		render(Optional.empty(), Optional.empty());
 	}
 
 	public void render(Optional<RenderManager> entityRenderManager) {
+		render(Optional.empty(), entityRenderManager);
+	}
+
+	public void render(Optional<IBlockAccess> access, Optional<RenderManager> entityRenderManager) {
 		Tessellator tessellator = Tessellator.getInstance();
 		WorldRenderer worldRenderer = tessellator.getWorldRenderer();
 		worldRenderer.setColorRGBA_F(1, 1, 1, 1);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/BWModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/BWModel.java
@@ -24,6 +24,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import nova.core.render.model.CustomModel;
 import nova.core.render.model.MeshModel;
 import nova.core.render.texture.EntityTexture;
 import nova.core.render.texture.Texture;
@@ -54,8 +55,7 @@ public class BWModel extends MeshModel {
 			model -> {
 				if (model instanceof MeshModel) {
 					MeshModel meshModel = (MeshModel) model;
-					meshModel.faces.forEach(face ->
-					{
+					meshModel.faces.forEach(face -> {
 						// Brightness is defined as: skyLight << 20 | blockLight << 4
 						if (face.getBrightness() >= 0) {
 							worldRenderer.setBrightness((int) (face.getBrightness() * (15 << 20 | 11 << 4)));
@@ -64,7 +64,7 @@ public class BWModel extends MeshModel {
 							worldRenderer.setBrightness(15 << 20 | 11 << 4);
 						}
 
-						worldRenderer.setNormal((int) face.normal.getX(), (int) face.normal.getY(), (int) face.normal.getZ());
+						worldRenderer.setNormal((float) face.normal.getX(), (float) face.normal.getY(), (float) face.normal.getZ());
 
 						if (face.texture.isPresent()) {
 							if (entityRenderManager.isPresent() && face.texture.get() instanceof EntityTexture) {
@@ -100,8 +100,10 @@ public class BWModel extends MeshModel {
 							);
 						}
 					});
+				} else if (model instanceof CustomModel) {
+					CustomModel customModel = (CustomModel) model;
+					customModel.render.accept(customModel);
 				}
-				//TODO: Handle BW Rendering
 			}
 		);
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWEmptyModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWEmptyModel.java
@@ -23,7 +23,6 @@ package nova.core.wrapper.mc.forge.v18.wrapper.render;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartBlockModel;
@@ -40,13 +39,13 @@ public class FWEmptyModel extends FWSmartModel implements ISmartBlockModel, ISma
 
 	//Block rendering
 	@Override
-	public IBakedModel handleBlockState(IBlockState state) {
+	public ISmartBlockModel handleBlockState(IBlockState state) {
 		return this;
 	}
 
-	//Itemblock rendering
+	//Item rendering
 	@Override
-	public IBakedModel handleItemState(ItemStack stack) {
+	public ISmartItemModel handleItemState(ItemStack stack) {
 		return this;
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartBlockModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartBlockModel.java
@@ -24,7 +24,6 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
-import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartBlockModel;
@@ -37,9 +36,8 @@ import nova.core.item.ItemBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
 import nova.internal.core.Game;
 
-import javax.vecmath.Vector3f;
-
 import java.util.List;
+import javax.vecmath.Vector3f;
 
 /**
  * Generates a smart model based on a NOVA Model
@@ -50,6 +48,7 @@ public class FWSmartBlockModel extends FWSmartModel implements ISmartBlockModel,
 	private final Block block;
 	private final boolean isItem;
 
+	@SuppressWarnings("deprecation")
 	public FWSmartBlockModel(Block block, boolean isItem) {
 		super();
 		this.block = block;
@@ -62,7 +61,7 @@ public class FWSmartBlockModel extends FWSmartModel implements ISmartBlockModel,
 
 	//Block rendering
 	@Override
-	public IBakedModel handleBlockState(IBlockState state) {
+	public ISmartBlockModel handleBlockState(IBlockState state) {
 		FWBlock block = (FWBlock) state.getBlock();
 
 		Block blockInstance = block.getBlockInstance(block.lastExtendedWorld, Game.natives().toNova(block.lastExtendedStatePos));
@@ -74,9 +73,9 @@ public class FWSmartBlockModel extends FWSmartModel implements ISmartBlockModel,
 		return new FWEmptyModel();
 	}
 
-	//Itemblock rendering
+	//Item rendering
 	@Override
-	public IBakedModel handleItemState(ItemStack stack) {
+	public ISmartItemModel handleItemState(ItemStack stack) {
 		ItemBlock item = Game.natives().toNova(stack);
 
 		if (item.components.has(Renderer.class) || block.components.has(Renderer.class)) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartBlockModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartBlockModel.java
@@ -32,8 +32,9 @@ import nova.core.block.Block;
 import nova.core.component.renderer.Renderer;
 import nova.core.component.renderer.StaticRenderer;
 import nova.core.item.Item;
+import nova.core.wrapper.mc.forge.v18.wrapper.VectorConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
-import nova.internal.core.Game;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 
 import java.util.List;
 import java.util.Optional;
@@ -72,7 +73,7 @@ public class FWSmartBlockModel extends FWSmartModel implements ISmartBlockModel,
 	public ISmartBlockModel handleBlockState(IBlockState state) {
 		FWBlock block = (FWBlock) state.getBlock();
 
-		Block blockInstance = block.getBlockInstance(block.lastExtendedWorld, Game.natives().toNova(block.lastExtendedStatePos));
+		Block blockInstance = block.getBlockInstance(block.lastExtendedWorld, VectorConverter.instance().toNova(block.lastExtendedStatePos));
 
 		if (blockInstance.components.has(StaticRenderer.class)) {
 			return new FWSmartBlockModel(blockInstance);
@@ -84,7 +85,7 @@ public class FWSmartBlockModel extends FWSmartModel implements ISmartBlockModel,
 	//Item rendering
 	@Override
 	public ISmartItemModel handleItemState(ItemStack stack) {
-		Item item = Game.natives().toNova(stack);
+		Item item = ItemConverter.instance().toNova(stack);
 
 		if (item.components.has(Renderer.class) || block.components.has(Renderer.class)) {
 			return new FWSmartBlockModel(block, item);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
@@ -23,7 +23,6 @@ package nova.core.wrapper.mc.forge.v18.wrapper.render;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
-import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartItemModel;
@@ -33,9 +32,8 @@ import nova.core.component.renderer.StaticRenderer;
 import nova.core.item.Item;
 import nova.internal.core.Game;
 
-import javax.vecmath.Vector3f;
 import java.util.List;
-import java.util.Optional;
+import javax.vecmath.Vector3f;
 
 /**
  * Generates a smart model based on a NOVA Model
@@ -45,6 +43,7 @@ public class FWSmartItemModel extends FWSmartModel implements ISmartItemModel, I
 
 	private final Item item;
 
+	@SuppressWarnings("deprecation")
 	public FWSmartItemModel(Item item) {
 		super();
 		this.item = item;
@@ -56,8 +55,9 @@ public class FWSmartItemModel extends FWSmartModel implements ISmartItemModel, I
 			new ItemTransformVec3f(new Vector3f(-30, 135, 0), new Vector3f(), new Vector3f(1.6F, 1.6F, 1.6F))); // GUI
 	}
 
+	//Item rendering
 	@Override
-	public IBakedModel handleItemState(ItemStack stack) {
+	public ISmartItemModel handleItemState(ItemStack stack) {
 		Item item = Game.natives().toNova(stack);
 
 		if (item.components.has(Renderer.class)) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
@@ -28,7 +28,7 @@ import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartItemModel;
 import nova.core.component.renderer.Renderer;
 import nova.core.item.Item;
-import nova.internal.core.Game;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 
 import java.util.List;
 import javax.vecmath.Vector3f;
@@ -56,7 +56,7 @@ public class FWSmartItemModel extends FWSmartModel implements ISmartItemModel, I
 	//Item rendering
 	@Override
 	public ISmartItemModel handleItemState(ItemStack stack) {
-		Item item = Game.natives().toNova(stack);
+		Item item = ItemConverter.instance().toNova(stack);
 
 		if (item.components.has(Renderer.class)) {
 			return new FWSmartItemModel(item);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
@@ -26,9 +26,7 @@ import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartItemModel;
-import nova.core.component.renderer.DynamicRenderer;
 import nova.core.component.renderer.Renderer;
-import nova.core.component.renderer.StaticRenderer;
 import nova.core.item.Item;
 import nova.internal.core.Game;
 
@@ -71,15 +69,7 @@ public class FWSmartItemModel extends FWSmartModel implements ISmartItemModel, I
 	public List<BakedQuad> getGeneralQuads() {
 		BWModel model = new BWModel();
 		model.matrix.translate(0.5, 0.5, 0.5);
-
-		if (item.components.has(StaticRenderer.class)) {
-			StaticRenderer staticRenderer = item.components.get(StaticRenderer.class);
-			staticRenderer.onRender.accept(model);
-		} else if (item.components.has(DynamicRenderer.class)) {
-			DynamicRenderer dynamicRenderer = item.components.get(DynamicRenderer.class);
-			dynamicRenderer.onRender.accept(model);
-		}
-
+		item.components.getSet(Renderer.class).forEach(r -> r.onRender.accept(model));
 		return modelToQuads(model);
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartModel.java
@@ -25,6 +25,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
@@ -33,6 +34,7 @@ import nova.core.render.model.Model;
 import nova.core.render.model.Vertex;
 import nova.core.util.Direction;
 import nova.core.wrapper.mc.forge.v18.render.RenderUtility;
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,15 +47,22 @@ import java.util.stream.Stream;
  */
 public abstract class FWSmartModel implements IFlexibleBakedModel {
 
+	protected static final VertexFormat NOVA_VERTEX_FORMAT = DefaultVertexFormats.ITEM;
+
 	protected final VertexFormat format;
 	// Default item transforms. Can be changed in subclasses.
+	@SuppressWarnings("deprecation")
 	protected ItemCameraTransforms itemCameraTransforms = ItemCameraTransforms.DEFAULT;
 
-	public FWSmartModel() {
-		this.format = new VertexFormat();
+	protected FWSmartModel(VertexFormat format) {
+		this.format = format;
 	}
 
-	public static int[] vertexToInts(Vertex vertex, TextureAtlasSprite texture) {
+	public FWSmartModel() {
+		this(NOVA_VERTEX_FORMAT);
+	}
+
+	public static int[] vertexToInts(Vertex vertex, TextureAtlasSprite texture, Vector3D normal) {
 		return new int[] {
 			Float.floatToRawIntBits((float) vertex.vec.getX()),
 			Float.floatToRawIntBits((float) vertex.vec.getY()),
@@ -61,7 +70,9 @@ public abstract class FWSmartModel implements IFlexibleBakedModel {
 			vertex.color.rgba(),
 			Float.floatToRawIntBits(texture.getInterpolatedU(16 * vertex.uv.getX())),
 			Float.floatToRawIntBits(texture.getInterpolatedV(16 * vertex.uv.getY())),
-			0
+			((((byte)(normal.getX() * 127)) & 0xFF) |
+			((((byte)(normal.getY() * 127)) & 0xFF) << 8) |
+			((((byte)(normal.getZ() * 127)) & 0xFF) << 16))
 		};
 	}
 
@@ -81,7 +92,7 @@ public abstract class FWSmartModel implements IFlexibleBakedModel {
 										.orElse(Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite());
 									List<int[]> vertexData = face.vertices
 										.stream()
-										.map(v -> vertexToInts(v, texture))
+										.map(v -> vertexToInts(v, texture, face.normal))
 										.collect(Collectors.toList());
 
 									int[] data = Ints.concat(vertexData.toArray(new int[][] {}));
@@ -128,6 +139,7 @@ public abstract class FWSmartModel implements IFlexibleBakedModel {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public ItemCameraTransforms getItemCameraTransforms() {
 		return itemCameraTransforms;
 	}

--- a/src/main/java/nova/core/render/model/CustomModel.java
+++ b/src/main/java/nova/core/render/model/CustomModel.java
@@ -48,7 +48,7 @@ public class CustomModel extends Model {
 	}
 
 	@Override
-	protected Model newModel(String name) {
+	protected CustomModel newModel(String name) {
 		return new CustomModel(name, render);
 	}
 

--- a/src/main/java/nova/core/render/model/MeshModel.java
+++ b/src/main/java/nova/core/render/model/MeshModel.java
@@ -82,6 +82,7 @@ public class MeshModel extends Model {
 		faces.add(Face);
 	}
 
+	@Override
 	public Set<Model> flatten(MatrixStack matrixStack) {
 		Set<Model> models = new HashSet<>();
 
@@ -110,7 +111,7 @@ public class MeshModel extends Model {
 	}
 
 	@Override
-	protected Model newModel(String name) {
+	protected MeshModel newModel(String name) {
 		return new MeshModel(name);
 	}
 


### PR DESCRIPTION
This PR implements fixes for forward rendering.

### List of fixes:
- Items now render in 1.7.10 (They still render as 3D in GUIs)
- Model face normals are now floating point numbers
- Calling `MeshModel.newModel()` now returns a `MeshModel`
- Calling `CustomModel.newModel()` now returns a `CustomModel`