### PR TITLE
Fix NPE in DirectionConverter

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
@@ -42,7 +42,9 @@ public class DirectionConverter implements NativeConverter<Direction, EnumFacing
 
 	@Override
 	public Direction toNova(EnumFacing nativeObj) {
-		switch (nativeObj) {
+		if (null == nativeObj)
+			return Direction.UNKNOWN;
+		else switch (nativeObj) {
 			case DOWN:  return Direction.DOWN;
 			case UP:    return Direction.UP;
 			case NORTH: return Direction.NORTH;

--- a/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverterTest.java
+++ b/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverterTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static nova.testutils.NovaAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Used to test {@link DirectionConverter}.
@@ -50,6 +51,7 @@ public class DirectionConverterTest {
 		assertThat(converter.toNova(EnumFacing.SOUTH)).isEqualTo(Direction.SOUTH);
 		assertThat(converter.toNova(EnumFacing.WEST)).isEqualTo(Direction.WEST);
 		assertThat(converter.toNova(EnumFacing.EAST)).isEqualTo(Direction.EAST);
+		assertThat(converter.toNova(null)).isEqualTo(Direction.UNKNOWN);
 	}
 
 	@Test

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverter.java
@@ -42,7 +42,9 @@ public class DirectionConverter implements NativeConverter<Direction, EnumFacing
 
 	@Override
 	public Direction toNova(EnumFacing nativeObj) {
-		switch (nativeObj) {
+		if (null == nativeObj)
+			return Direction.UNKNOWN;
+		else switch (nativeObj) {
 			case DOWN:  return Direction.DOWN;
 			case UP:    return Direction.UP;
 			case NORTH: return Direction.NORTH;

--- a/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverterTest.java
+++ b/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverterTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static nova.testutils.NovaAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Used to test {@link DirectionConverter}.
@@ -49,6 +50,7 @@ public class DirectionConverterTest {
 		assertThat(converter.toNova(EnumFacing.SOUTH)).isEqualTo(Direction.SOUTH);
 		assertThat(converter.toNova(EnumFacing.WEST)).isEqualTo(Direction.WEST);
 		assertThat(converter.toNova(EnumFacing.EAST)).isEqualTo(Direction.EAST);
+		assertThat(converter.toNova(null)).isEqualTo(Direction.UNKNOWN);
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes a NPE in the `DirectionConverter` switch statement.
Minecraft’s `EnumFacing` can be null, but a switch statement throws a NPE when it is passed a null parameter instead of going to the `default` case.