### PR TITLE
Fix argument mismatch when passing block argument in BWWorld

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/world/BWWorld.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/world/BWWorld.java
@@ -84,7 +84,7 @@ public class BWWorld extends World {
 			return Optional.of(((FWBlock) mcBlock).getBlockInstance(access, position));
 		} else {
 			BWBlock block = new BWBlock(mcBlock, this, position);
-			Game.blocks().get(net.minecraft.block.Block.blockRegistry.getNameForObject(block))
+			Game.blocks().get(net.minecraft.block.Block.blockRegistry.getNameForObject(mcBlock))
 				.ifPresent(blockFactory -> block.components.getOrAdd(new FactoryProvider(blockFactory)));
 			return Optional.of(block);
 		}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/BWWorld.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/BWWorld.java
@@ -88,7 +88,7 @@ public class BWWorld extends World {
 			return Optional.of(((FWBlock) mcBlock).getBlockInstance(access, position));
 		} else {
 			BWBlock block = new BWBlock(mcBlock, this, position);
-			Game.blocks().get(net.minecraft.block.Block.blockRegistry.getNameForObject(block).toString())
+			Game.blocks().get(net.minecraft.block.Block.blockRegistry.getNameForObject(mcBlock).toString())
 				.ifPresent(blockFactory -> block.components.getOrAdd(new FactoryProvider(blockFactory)));
 			return Optional.of(block);
 		}


### PR DESCRIPTION
This fixes a bug that I thought I fixed before #270 was merged.