### PR TITLE
Fix compiler warnings in tests

### DIFF
--- a/src/test/java/nova/core/component/ComponentProviderTest.java
+++ b/src/test/java/nova/core/component/ComponentProviderTest.java
@@ -12,12 +12,12 @@ import static nova.testutils.NovaAssertions.assertThat;
  */
 public class ComponentProviderTest {
 
-	private ComponentProvider provider;
+	private ComponentProvider<?> provider;
 
 	@Before
 	public void setUp() throws Exception {
-		provider = new ComponentProvider() {
-		};
+		// TODO: When Java 9 comes out, use the diamond operator
+		provider = new ComponentProvider<ComponentMap>() {};
 	}
 
 	@Test

--- a/src/test/java/nova/core/nativewrapper/NativeManagerTest.java
+++ b/src/test/java/nova/core/nativewrapper/NativeManagerTest.java
@@ -43,8 +43,16 @@ public class NativeManagerTest {
 			val = v;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			return obj instanceof Type1 && ((Type1) obj).val == val;
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = 7;
+			hash = 67 * hash + this.val;
+			return hash;
 		}
 	}
 
@@ -55,8 +63,16 @@ public class NativeManagerTest {
 			val = v;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			return obj instanceof Type2 && ((Type2) obj).val == val;
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = 7;
+			hash = 67 * hash + this.val;
+			return hash;
 		}
 	}
 

--- a/src/test/java/nova/internal/core/di/OptionalDITest.java
+++ b/src/test/java/nova/internal/core/di/OptionalDITest.java
@@ -83,7 +83,7 @@ public class OptionalDITest {
 			bind(TestManager.class).toConstructor();
 			try {
 				starbind(Map.class).to(
-					HashMap.class.getConstructor(new Class[] {}), (Parameter[]) null);
+					HashMap.class.getConstructor(new Class<?>[] {}), (Parameter[]) null);
 			} catch (NoSuchMethodException | SecurityException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
This PR fixes all remaining compiler warnings in tests. (`FakeRenderModule.java:41` was fixed by #265)

Does work on #184.