### PR TITLE
Add instance() method to all NativeConverter implementations

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/CategoryConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/CategoryConverter.java
@@ -37,10 +37,10 @@ import java.util.Arrays;
  *
  * @author ExE Boss
  */
-public class CategoryConverter implements NativeConverter<Category, CreativeTabs>{
+public class CategoryConverter implements NativeConverter<Category, CreativeTabs> {
 
 	public static CategoryConverter instance() {
-		return (CategoryConverter) Game.natives().getNative(Category.class, CreativeTabs.class);
+		return Game.natives().getNative(Category.class, CreativeTabs.class);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
@@ -23,12 +23,17 @@ package nova.core.wrapper.mc.forge.v17.wrapper;
 import net.minecraft.util.EnumFacing;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.util.Direction;
+import nova.internal.core.Game;
 
 /**
  *
  * @author ExE Boss
  */
 public class DirectionConverter implements NativeConverter<Direction, EnumFacing> {
+
+	public static DirectionConverter instance() {
+		return (DirectionConverter) Game.natives().getNative(Direction.class, EnumFacing.class);
+	}
 
 	@Override
 	public Class<Direction> getNovaSide() {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
@@ -32,7 +32,7 @@ import nova.internal.core.Game;
 public class DirectionConverter implements NativeConverter<Direction, EnumFacing> {
 
 	public static DirectionConverter instance() {
-		return (DirectionConverter) Game.natives().getNative(Direction.class, EnumFacing.class);
+		return Game.natives().getNative(Direction.class, EnumFacing.class);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/assets/AssetConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/assets/AssetConverter.java
@@ -35,7 +35,7 @@ import nova.internal.core.Game;
 public final class AssetConverter implements NativeConverter<Asset, ResourceLocation> {
 
 	public static AssetConverter instance() {
-		return (AssetConverter) Game.natives().getNative(Asset.class, ResourceLocation.class);
+		return Game.natives().getNative(Asset.class, ResourceLocation.class);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
@@ -50,7 +50,7 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 	public final HashMap<BlockFactory, net.minecraft.block.Block> blockFactoryMap = new HashMap<>();
 
 	public static BlockConverter instance() {
-		return (BlockConverter) Game.natives().getNative(Block.class, net.minecraft.block.Block.class);
+		return Game.natives().getNative(Block.class, net.minecraft.block.Block.class);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/world/WorldConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/world/WorldConverter.java
@@ -31,6 +31,11 @@ import java.util.Optional;
  * @author Calclavia
  */
 public class WorldConverter implements NativeConverter<World, IBlockAccess> {
+
+	public static WorldConverter instance() {
+		return Game.natives().getNative(World.class, IBlockAccess.class);
+	}
+
 	@Override
 	public Class<World> getNovaSide() {
 		return World.class;

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/cuboid/CuboidConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/cuboid/CuboidConverter.java
@@ -23,12 +23,18 @@ package nova.core.wrapper.mc.forge.v17.wrapper.cuboid;
 import net.minecraft.util.AxisAlignedBB;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.util.shape.Cuboid;
+import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 /**
  * @author Calclavia
  */
 public class CuboidConverter implements NativeConverter<Cuboid, AxisAlignedBB> {
+
+	public static CuboidConverter instance() {
+		return Game.natives().getNative(Cuboid.class, AxisAlignedBB.class);
+	}
+
 	@Override
 	public Class<Cuboid> getNovaSide() {
 		return Cuboid.class;

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/data/DataConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/data/DataConverter.java
@@ -46,7 +46,7 @@ import java.util.Set;
 public class DataConverter implements NativeConverter<Data, NBTTagCompound> {
 
 	public static DataConverter instance() {
-		return (DataConverter) Game.natives().getNative(Data.class, NBTTagCompound.class);
+		return Game.natives().getNative(Data.class, NBTTagCompound.class);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/EntityConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/EntityConverter.java
@@ -37,6 +37,10 @@ import java.util.Optional;
 
 public class EntityConverter implements NativeConverter<Entity, net.minecraft.entity.Entity>, ForgeLoadable {
 
+	public static EntityConverter instance() {
+		return Game.natives().getNative(Entity.class, net.minecraft.entity.Entity.class);
+	}
+
 	@Override
 	public Class<Entity> getNovaSide() {
 		return Entity.class;

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/inventory/InventoryConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/inventory/InventoryConverter.java
@@ -23,11 +23,17 @@ package nova.core.wrapper.mc.forge.v17.wrapper.inventory;
 import net.minecraft.inventory.IInventory;
 import nova.core.component.inventory.Inventory;
 import nova.core.nativewrapper.NativeConverter;
+import nova.internal.core.Game;
 
 /**
  * @author Calclavia
  */
 public class InventoryConverter implements NativeConverter<Inventory, IInventory> {
+
+	public static InventoryConverter instance() {
+		return Game.natives().getNative(Inventory.class, IInventory.class);
+	}
+
 	@Override
 	public Class<Inventory> getNovaSide() {
 		return Inventory.class;
@@ -55,5 +61,4 @@ public class InventoryConverter implements NativeConverter<Inventory, IInventory
 		}
 		return new FWInventory(novaObj);
 	}
-
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
@@ -55,7 +55,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 	private final HashBiMap<ItemFactory, MinecraftItemMapping> map = HashBiMap.create();
 
 	public static ItemConverter instance() {
-		return (ItemConverter) Game.natives().getNative(Item.class, ItemStack.class);
+		return Game.natives().getNative(Item.class, ItemStack.class);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/CategoryConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/CategoryConverter.java
@@ -37,10 +37,10 @@ import java.util.Arrays;
  *
  * @author ExE Boss
  */
-public class CategoryConverter implements NativeConverter<Category, CreativeTabs>{
+public class CategoryConverter implements NativeConverter<Category, CreativeTabs> {
 
 	public static CategoryConverter instance() {
-		return (CategoryConverter) Game.natives().getNative(Category.class, CreativeTabs.class);
+		return Game.natives().getNative(Category.class, CreativeTabs.class);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverter.java
@@ -23,12 +23,17 @@ package nova.core.wrapper.mc.forge.v18.wrapper;
 import net.minecraft.util.EnumFacing;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.util.Direction;
+import nova.internal.core.Game;
 
 /**
  *
  * @author ExE Boss
  */
 public class DirectionConverter implements NativeConverter<Direction, EnumFacing> {
+
+	public static DirectionConverter instance() {
+		return (DirectionConverter) Game.natives().getNative(Direction.class, EnumFacing.class);
+	}
 
 	@Override
 	public Class<Direction> getNovaSide() {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverter.java
@@ -32,7 +32,7 @@ import nova.internal.core.Game;
 public class DirectionConverter implements NativeConverter<Direction, EnumFacing> {
 
 	public static DirectionConverter instance() {
-		return (DirectionConverter) Game.natives().getNative(Direction.class, EnumFacing.class);
+		return Game.natives().getNative(Direction.class, EnumFacing.class);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/VectorConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/VectorConverter.java
@@ -22,9 +22,15 @@ package nova.core.wrapper.mc.forge.v18.wrapper;
 
 import net.minecraft.util.BlockPos;
 import nova.core.nativewrapper.NativeConverter;
+import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 public class VectorConverter implements NativeConverter<Vector3D, BlockPos> {
+
+	public static VectorConverter instance() {
+		return Game.natives().getNative(Vector3D.class, BlockPos.class);
+	}
+
 	@Override
 	public Class<Vector3D> getNovaSide() {
 		return Vector3D.class;

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/assets/AssetConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/assets/AssetConverter.java
@@ -32,7 +32,7 @@ import nova.internal.core.Game;
 public final class AssetConverter implements NativeConverter<Asset, ResourceLocation> {
 
 	public static AssetConverter instance() {
-		return (AssetConverter) Game.natives().getNative(Asset.class, ResourceLocation.class);
+		return Game.natives().getNative(Asset.class, ResourceLocation.class);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
@@ -51,7 +51,7 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 	public final HashMap<BlockFactory, net.minecraft.block.Block> blockFactoryMap = new HashMap<>();
 
 	public static BlockConverter instance() {
-		return (BlockConverter) Game.natives().getNative(Block.class, net.minecraft.block.Block.class);
+		return Game.natives().getNative(Block.class, net.minecraft.block.Block.class);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/WorldConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/WorldConverter.java
@@ -31,6 +31,11 @@ import java.util.Optional;
  * @author Calclavia
  */
 public class WorldConverter implements NativeConverter<World, IBlockAccess> {
+
+	public static WorldConverter instance() {
+		return Game.natives().getNative(World.class, IBlockAccess.class);
+	}
+
 	@Override
 	public Class<World> getNovaSide() {
 		return World.class;

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/cuboid/CuboidConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/cuboid/CuboidConverter.java
@@ -23,12 +23,18 @@ package nova.core.wrapper.mc.forge.v18.wrapper.cuboid;
 import net.minecraft.util.AxisAlignedBB;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.util.shape.Cuboid;
+import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 /**
  * @author Calclavia
  */
 public class CuboidConverter implements NativeConverter<Cuboid, AxisAlignedBB> {
+
+	public static CuboidConverter instance() {
+		return Game.natives().getNative(Cuboid.class, AxisAlignedBB.class);
+	}
+
 	@Override
 	public Class<Cuboid> getNovaSide() {
 		return Cuboid.class;

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/data/DataConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/data/DataConverter.java
@@ -46,7 +46,7 @@ import java.util.Set;
 public class DataConverter implements NativeConverter<Data, NBTTagCompound> {
 
 	public static DataConverter instance() {
-		return (DataConverter) Game.natives().getNative(Data.class, NBTTagCompound.class);
+		return Game.natives().getNative(Data.class, NBTTagCompound.class);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/EntityConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/EntityConverter.java
@@ -38,6 +38,10 @@ import java.util.Optional;
 
 public class EntityConverter implements NativeConverter<Entity, net.minecraft.entity.Entity>, ForgeLoadable {
 
+	public static EntityConverter instance() {
+		return Game.natives().getNative(Entity.class, net.minecraft.entity.Entity.class);
+	}
+
 	@Override
 	public Class<Entity> getNovaSide() {
 		return Entity.class;

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/inventory/InventoryConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/inventory/InventoryConverter.java
@@ -23,11 +23,17 @@ package nova.core.wrapper.mc.forge.v18.wrapper.inventory;
 import net.minecraft.inventory.IInventory;
 import nova.core.component.inventory.Inventory;
 import nova.core.nativewrapper.NativeConverter;
+import nova.internal.core.Game;
 
 /**
  * @author Calclavia
  */
 public class InventoryConverter implements NativeConverter<Inventory, IInventory> {
+
+	public static InventoryConverter instance() {
+		return Game.natives().getNative(Inventory.class, IInventory.class);
+	}
+
 	@Override
 	public Class<Inventory> getNovaSide() {
 		return Inventory.class;
@@ -55,5 +61,4 @@ public class InventoryConverter implements NativeConverter<Inventory, IInventory
 		}
 		return new FWInventory(novaObj);
 	}
-
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
@@ -56,7 +56,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 	private final HashBiMap<ItemFactory, MinecraftItemMapping> map = HashBiMap.create();
 
 	public static ItemConverter instance() {
-		return (ItemConverter) Game.natives().getNative(Item.class, ItemStack.class);
+		return Game.natives().getNative(Item.class, ItemStack.class);
 	}
 
 	@Override

--- a/src/test/java/nova/core/nativewrapper/NativeManagerTest.java
+++ b/src/test/java/nova/core/nativewrapper/NativeManagerTest.java
@@ -61,18 +61,22 @@ public class NativeManagerTest {
 	}
 
 	public static class TestConverter implements NativeConverter<Type1, Type2> {
+		@Override
 		public Type2 toNative(Type1 o) {
 			return new Type2(o.val);
 		}
 
+		@Override
 		public Type1 toNova(Type2 o) {
 			return new Type1(o.val);
 		}
 
+		@Override
 		public Class<Type1> getNovaSide() {
 			return Type1.class;
 		}
 
+		@Override
 		public Class<Type2> getNativeSide() {
 			return Type2.class;
 		}


### PR DESCRIPTION
Should have been in #243 and #275

### Completed:
- [x] Add an `instance()` method to all `NativeConverter` implementations
- [x] Fix warnings in `NativeManager`
- [x] Autocast result of `NativeManager.getNative` and `NativeManager.findConverter`