### PR TITLE
Implement correct NOVA ID namespacing

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/StaticForwarder.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/StaticForwarder.java
@@ -29,6 +29,7 @@ import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTile;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTileLoader;
 import nova.internal.core.Game;
+import nova.internal.core.launch.NovaLauncher;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 /**
@@ -60,12 +61,29 @@ public class StaticForwarder {
 	}
 
 	/**
+	 * Checks if the name's prefix is a nova mod ID prefix.
+	 *
+	 * @param name The prefix to check
+	 * @return If the name's prefix is a nova mod ID prefix.
+	 */
+	public static boolean hasNovaPrefix(String name) {
+		if (!name.contains(":"))
+			return false;
+		String prefix = name.substring(0, name.lastIndexOf(':'));
+		return NovaLauncher.instance()
+			.map(loader -> loader.getLoadedMods()
+				.stream()
+				.anyMatch(mod -> prefix.startsWith(mod.id())))
+			.orElse(false);
+	}
+
+	/**
 	 * Checks if the prefix is equal to the NOVA mod ID ("nova").
 	 *
 	 * @param prefix The prefix to check
 	 * @return If the prefix is equal to the NOVA mod ID ("nova").
 	 */
-	public static boolean addPrefix$isNovaPrefix(String prefix) {
+	public static boolean isNovaPrefix(String prefix) {
 		return NovaMinecraft.id.equals(prefix);
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/StaticForwarder.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/StaticForwarder.java
@@ -25,6 +25,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.chunk.Chunk;
 import nova.core.event.BlockEvent;
+import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTile;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTileLoader;
 import nova.internal.core.Game;
@@ -35,6 +36,8 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
  * @author Calclavia
  */
 public class StaticForwarder {
+
+	private StaticForwarder() {}
 
 	public static void chunkSetBlockEvent(Chunk chunk, int x, int y, int z, Block oldBlock, int oldMeta, Block newBlock, int newMeta) {
 		// Publish the event
@@ -54,5 +57,15 @@ public class StaticForwarder {
 		} else {
 			return clazz.newInstance();
 		}
+	}
+
+	/**
+	 * Checks if the prefix is equal to the NOVA mod ID ("nova").
+	 *
+	 * @param prefix The prefix to check
+	 * @return If the prefix is equal to the NOVA mod ID ("nova").
+	 */
+	public static boolean addPrefix$isNovaPrefix(String prefix) {
+		return NovaMinecraft.id.equals(prefix);
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/GameDataTransformer.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/GameDataTransformer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.core.wrapper.mc.forge.v17.asm.transformers;
+
+import nova.core.wrapper.mc.forge.v17.asm.lib.ASMHelper;
+import nova.core.wrapper.mc.forge.v17.asm.lib.ObfMapping;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+/**
+ * @author ExE Boss
+ */
+public class GameDataTransformer implements Transformer {
+
+	@Override
+	public void transform(ClassNode cnode) {
+
+		System.out.println("[NOVA] Transforming GameData class for correct NOVA mod id mapping.");
+
+		ObfMapping mapping = new ObfMapping("cpw/mods/fml/common/registry/GameData", "addPrefix", "(Ljava/lang/String;)Ljava/lang/String;");
+
+		MethodNode method = ASMHelper.findMethod(mapping, cnode);
+
+		if (method == null) {
+			throw new RuntimeException("[NOVA] Lookup " + mapping + " failed!");
+		}
+
+		System.out.println("[NOVA] Transforming method " + method.name);
+
+		@SuppressWarnings("unchecked")
+		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(49);
+
+		InsnList list = new InsnList();
+		list.add(new VarInsnNode(ALOAD, 4));
+		list.add(new MethodInsnNode(INVOKESTATIC, "nova/core/wrapper/mc/forge/v17/asm/StaticForwarder", "addPrefix$isNovaPrefix", "(Ljava/lang/String;)Z", false));
+		list.add(new JumpInsnNode(IFNE, prev.label));
+
+		method.instructions.insert(prev, list);
+
+		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+	}
+}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/GameDataTransformer.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/GameDataTransformer.java
@@ -35,15 +35,18 @@ public class GameDataTransformer implements Transformer {
 
 	@Override
 	public void transform(ClassNode cnode) {
-
 		System.out.println("[NOVA] Transforming GameData class for correct NOVA mod id mapping.");
+		transformAddPrefix(cnode);
+		transformRegisterBlock(cnode);
+		transformRegisterItem(cnode);
+	}
 
+	private void transformAddPrefix(ClassNode cnode) {
 		ObfMapping mapping = new ObfMapping("cpw/mods/fml/common/registry/GameData", "addPrefix", "(Ljava/lang/String;)Ljava/lang/String;");
-
 		MethodNode method = ASMHelper.findMethod(mapping, cnode);
 
 		if (method == null) {
-			throw new RuntimeException("[NOVA] Lookup " + mapping + " failed!");
+			throw new IllegalStateException("[NOVA] Lookup " + mapping + " failed!");
 		}
 
 		System.out.println("[NOVA] Transforming method " + method.name);
@@ -53,7 +56,67 @@ public class GameDataTransformer implements Transformer {
 
 		InsnList list = new InsnList();
 		list.add(new VarInsnNode(ALOAD, 4));
-		list.add(new MethodInsnNode(INVOKESTATIC, "nova/core/wrapper/mc/forge/v17/asm/StaticForwarder", "addPrefix$isNovaPrefix", "(Ljava/lang/String;)Z", false));
+		list.add(new MethodInsnNode(INVOKESTATIC, "nova/core/wrapper/mc/forge/v17/asm/StaticForwarder", "isNovaPrefix", "(Ljava/lang/String;)Z", false));
+		list.add(new JumpInsnNode(IFNE, prev.label));
+
+		method.instructions.insert(prev, list);
+
+		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+	}
+
+	private void transformRegisterBlock(ClassNode cnode) {
+		ObfMapping obfMap = new ObfMapping("cpw/mods/fml/common/registry/GameData", "registerBlock", "(Laji;Ljava/lang/String;)I");
+		ObfMapping deobfMap = new ObfMapping("cpw/mods/fml/common/registry/GameData", "registerBlock", "(Lnet/minecraft/block/Block;Ljava/lang/String;)I");
+
+		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
+
+		if (method == null) {
+			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			method = ASMHelper.findMethod(deobfMap, cnode);
+
+			if (method == null) {
+				throw new IllegalStateException("[NOVA] Lookup " + deobfMap + " failed!");
+			}
+		}
+
+		System.out.println("[NOVA] Transforming method " + method.name);
+
+		@SuppressWarnings("unchecked")
+		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(12);
+
+		InsnList list = new InsnList();
+		list.add(new VarInsnNode(ALOAD, 2));
+		list.add(new MethodInsnNode(INVOKESTATIC, "nova/core/wrapper/mc/forge/v17/asm/StaticForwarder", "hasNovaPrefix", "(Ljava/lang/String;)Z", false));
+		list.add(new JumpInsnNode(IFNE, prev.label));
+
+		method.instructions.insert(prev, list);
+
+		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+	}
+
+	private void transformRegisterItem(ClassNode cnode) {
+		ObfMapping obfMap = new ObfMapping("cpw/mods/fml/common/registry/GameData", "registerItem", "(Ladb;Ljava/lang/String;)I");
+		ObfMapping deobfMap = new ObfMapping("cpw/mods/fml/common/registry/GameData", "registerItem", "(Lnet/minecraft/item/Item;Ljava/lang/String;)I");
+
+		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
+
+		if (method == null) {
+			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			method = ASMHelper.findMethod(deobfMap, cnode);
+
+			if (method == null) {
+				throw new IllegalStateException("[NOVA] Lookup " + deobfMap + " failed!");
+			}
+		}
+
+		System.out.println("[NOVA] Transforming method " + method.name);
+
+		@SuppressWarnings("unchecked")
+		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(12);
+
+		InsnList list = new InsnList();
+		list.add(new VarInsnNode(ALOAD, 2));
+		list.add(new MethodInsnNode(INVOKESTATIC, "nova/core/wrapper/mc/forge/v17/asm/StaticForwarder", "hasNovaPrefix", "(Ljava/lang/String;)Z", false));
 		list.add(new JumpInsnNode(IFNE, prev.label));
 
 		method.instructions.insert(prev, list);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/Transformers.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/Transformers.java
@@ -37,6 +37,7 @@ public final class Transformers implements IClassTransformer {
 	public Transformers() {
 		registerTransformer(new ChunkTransformer(), "net.minecraft.world.chunk.Chunk");
 		registerTransformer(new TileEntityTransformer(), "net.minecraft.tileentity.TileEntity");
+		registerTransformer(new GameDataTransformer(), "cpw.mods.fml.common.registry.GameData");
 	}
 
 	public static void registerTransformer(Transformer transformer, String... classes) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
@@ -29,6 +29,7 @@ import nova.core.block.BlockFactory;
 import nova.core.block.BlockManager;
 import nova.core.component.Category;
 import nova.core.event.BlockEvent;
+import nova.core.loader.Mod;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.wrapper.mc.forge.v17.launcher.ForgeLoadable;
 import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
@@ -37,6 +38,7 @@ import nova.core.wrapper.mc.forge.v17.wrapper.block.backward.BWBlock;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v17.wrapper.item.FWItemBlock;
 import nova.internal.core.Game;
+import nova.internal.core.launch.NovaLauncher;
 
 import java.util.HashMap;
 
@@ -134,7 +136,10 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 		FWBlock blockWrapper = new FWBlock(blockFactory);
 		blockFactoryMap.put(blockFactory, blockWrapper);
 		NovaMinecraft.proxy.registerBlock(blockWrapper);
-		GameRegistry.registerBlock(blockWrapper, FWItemBlock.class, blockFactory.getID());
+		String blockId = blockFactory.getID();
+		if (!blockId.contains(":"))
+			blockId = NovaLauncher.instance().flatMap(NovaLauncher::getCurrentMod).map(Mod::id).orElse("nova") + ':' + blockId;
+		GameRegistry.registerBlock(blockWrapper, FWItemBlock.class, blockId);
 
 		if (blockWrapper.dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {
 			//Add into creative tab

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
@@ -31,6 +31,7 @@ import nova.core.event.ItemEvent;
 import nova.core.item.Item;
 import nova.core.item.ItemBlock;
 import nova.core.item.ItemFactory;
+import nova.core.loader.Mod;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.retention.Data;
 import nova.core.wrapper.mc.forge.v17.launcher.ForgeLoadable;
@@ -38,8 +39,10 @@ import nova.core.wrapper.mc.forge.v17.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
 import nova.core.wrapper.mc.forge.v17.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.BlockConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 import nova.internal.core.launch.InitializationException;
+import nova.internal.core.launch.NovaLauncher;
 
 import java.util.Set;
 
@@ -85,7 +88,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 		} else {
 			ItemFactory itemFactory = registerMinecraftMapping(itemStack.getItem(), itemStack.getItemDamage());
 
-			Data data = itemStack.getTagCompound() != null ? Game.natives().toNova(itemStack.getTagCompound()) : new Data();
+			Data data = itemStack.getTagCompound() != null ? DataConverter.instance().toNova(itemStack.getTagCompound()) : new Data();
 			if (!itemStack.getHasSubtypes() && itemStack.getItemDamage() > 0) {
 				data.put("damage", itemStack.getItemDamage());
 			}
@@ -151,7 +154,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 		if (itemStack.stackSize <= 0) {
 			return null;
 		}
-		itemStack.setTagCompound(Game.natives().toNative(item.getFactory().save(item)));
+		itemStack.setTagCompound(DataConverter.instance().toNative(new FWNBTTagCompound(item), item.getFactory().save(item)));
 		WrapperEvent.UpdateItemEvent event = new WrapperEvent.UpdateItemEvent(item, itemStack);
 		Game.events().publish(event);
 		return itemStack;
@@ -203,7 +206,10 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 		// Don't register ItemBlocks twice
 		if (!(dummy instanceof ItemBlock)) {
 			NovaMinecraft.proxy.registerItem((FWItem) itemWrapper);
-			GameRegistry.registerItem(itemWrapper, itemFactory.getID());
+			String itemId = itemFactory.getID();
+			if (!itemId.contains(":"))
+				itemId = NovaLauncher.instance().flatMap(NovaLauncher::getCurrentMod).map(Mod::id).orElse("nova") + ':' + itemId;
+			GameRegistry.registerItem(itemWrapper, itemId);
 
 			if (dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {
 				//Add into creative tab

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/StaticForwarder.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/StaticForwarder.java
@@ -26,6 +26,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.world.chunk.Chunk;
 import nova.core.event.BlockEvent;
+import nova.core.wrapper.mc.forge.v18.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTile;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTileLoader;
 import nova.internal.core.Game;
@@ -36,6 +37,8 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
  * @author Calclavia
  */
 public class StaticForwarder {
+
+	private StaticForwarder() {}
 
 	public static void chunkSetBlockEvent(Chunk chunk, BlockPos pos, IBlockState oldBlockState, IBlockState newBlockState) {
 		// Publish the event
@@ -61,5 +64,15 @@ public class StaticForwarder {
 		} else {
 			return clazz.newInstance();
 		}
+	}
+
+	/**
+	 * Checks if the prefix is equal to the NOVA mod ID ("nova").
+	 *
+	 * @param prefix The prefix to check
+	 * @return If the prefix is equal to the NOVA mod ID ("nova").
+	 */
+	public static boolean addPrefix$isNovaPrefix(String prefix) {
+		return NovaMinecraft.id.equals(prefix);
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/StaticForwarder.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/StaticForwarder.java
@@ -30,6 +30,7 @@ import nova.core.wrapper.mc.forge.v18.launcher.NovaMinecraft;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTile;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTileLoader;
 import nova.internal.core.Game;
+import nova.internal.core.launch.NovaLauncher;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 /**
@@ -67,12 +68,29 @@ public class StaticForwarder {
 	}
 
 	/**
+	 * Checks if the name's prefix is a nova mod ID prefix.
+	 *
+	 * @param name The prefix to check
+	 * @return If the name's prefix is a nova mod ID prefix.
+	 */
+	public static boolean hasNovaPrefix(String name) {
+		if (!name.contains(":"))
+			return false;
+		String prefix = name.substring(0, name.lastIndexOf(':'));
+		return NovaLauncher.instance()
+			.map(loader -> loader.getLoadedMods()
+				.stream()
+				.anyMatch(mod -> prefix.startsWith(mod.id())))
+			.orElse(false);
+	}
+
+	/**
 	 * Checks if the prefix is equal to the NOVA mod ID ("nova").
 	 *
 	 * @param prefix The prefix to check
 	 * @return If the prefix is equal to the NOVA mod ID ("nova").
 	 */
-	public static boolean addPrefix$isNovaPrefix(String prefix) {
+	public static boolean isNovaPrefix(String prefix) {
 		return NovaMinecraft.id.equals(prefix);
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/GameDataTransformer.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/GameDataTransformer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.core.wrapper.mc.forge.v18.asm.transformers;
+
+import nova.core.wrapper.mc.forge.v18.asm.lib.ASMHelper;
+import nova.core.wrapper.mc.forge.v18.asm.lib.ObfMapping;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+/**
+ * @author ExE Boss
+ */
+public class GameDataTransformer implements Transformer {
+
+	@Override
+	public void transform(ClassNode cnode) {
+
+		System.out.println("[NOVA] Transforming GameData class for correct NOVA mod id mapping.");
+
+		ObfMapping mapping = new ObfMapping("net/minecraftforge/fml/common/registry/GameData", "addPrefix", "(Ljava/lang/String;)Ljava/lang/String;");
+
+		MethodNode method = ASMHelper.findMethod(mapping, cnode);
+
+		if (method == null) {
+			throw new RuntimeException("[NOVA] Lookup " + mapping + " failed!");
+		}
+
+		System.out.println("[NOVA] Transforming method " + method.name);
+
+		@SuppressWarnings("unchecked")
+		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(49);
+
+		InsnList list = new InsnList();
+		list.add(new VarInsnNode(ALOAD, 4));
+		list.add(new MethodInsnNode(INVOKESTATIC, "nova/core/wrapper/mc/forge/v18/asm/StaticForwarder", "addPrefix$isNovaPrefix", "(Ljava/lang/String;)Z", false));
+		list.add(new JumpInsnNode(IFNE, prev.label));
+
+		method.instructions.insert(prev, list);
+
+		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+	}
+}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/Transformers.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/Transformers.java
@@ -37,6 +37,7 @@ public final class Transformers implements IClassTransformer {
 	public Transformers() {
 		registerTransformer(new ChunkTransformer(), "net.minecraft.world.chunk.Chunk");
 		registerTransformer(new TileEntityTransformer(), "net.minecraft.tileentity.TileEntity");
+		registerTransformer(new GameDataTransformer(), "net.minecraftforge.fml.common.registry.GameData");
 	}
 
 	public static void registerTransformer(Transformer transformer, String... classes) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
@@ -29,6 +29,7 @@ import nova.core.block.BlockFactory;
 import nova.core.block.BlockManager;
 import nova.core.component.Category;
 import nova.core.event.BlockEvent;
+import nova.core.loader.Mod;
 import nova.core.nativewrapper.NativeConverter;
 import nova.core.wrapper.mc.forge.v18.launcher.ForgeLoadable;
 import nova.core.wrapper.mc.forge.v18.launcher.NovaMinecraft;
@@ -37,6 +38,7 @@ import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.CategoryConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.FWItemBlock;
 import nova.internal.core.Game;
+import nova.internal.core.launch.NovaLauncher;
 
 import java.util.HashMap;
 
@@ -134,7 +136,10 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 	private void registerNovaBlock(BlockFactory blockFactory) {
 		FWBlock blockWrapper = new FWBlock(blockFactory);
 		blockFactoryMap.put(blockFactory, blockWrapper);
-		GameRegistry.registerBlock(blockWrapper, FWItemBlock.class, blockFactory.getID());
+		String blockId = blockFactory.getID();
+		if (!blockId.contains(":"))
+			blockId = NovaLauncher.instance().flatMap(NovaLauncher::getCurrentMod).map(Mod::id).orElse("nova") + ':' + blockId;
+		GameRegistry.registerBlock(blockWrapper, FWItemBlock.class, blockId);
 		NovaMinecraft.proxy.postRegisterBlock(blockWrapper);
 
 		if (blockWrapper.dummy.components.has(Category.class) && FMLCommonHandler.instance().getSide().isClient()) {


### PR DESCRIPTION
This PR implements correct NOVA ID namespacing.

Previously, if a NOVA mod with the ID `example` with the ID `block`, it would get registered as `nova:example:block` when registered in Minecraft 1.7 and 1.8.

With this PR merged, if a NOVA mod with the ID `example` with the ID `block`, it would get registered as `example:block` when registered in Minecraft 1.7 and 1.8.

This feature wasn't merged because of Soni’s less than helpful review at https://github.com/NOVA-Team/NOVA-Core/pull/235#pullrequestreview-15632981 and in the discussion past my pinned message from 01/09/2017 on the discord server.

---

Moved from #235