### PR TITLE
Improve ComponentException arguments

### DIFF
--- a/src/main/java/nova/core/component/ComponentMap.java
+++ b/src/main/java/nova/core/component/ComponentMap.java
@@ -64,7 +64,7 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 	@SuppressWarnings("unchecked")
 	public final <C extends Component> C add(C component) {
 		if (has(component.getClass())) {
-			throw new ComponentException("Attempt to add two components of the type %s to " + this, component);
+			throw new ComponentException("Attempt to add two components of the type %s to %s", component, this);
 		}
 
 		//Place component into component map

--- a/src/main/java/nova/core/component/ComponentProvider.java
+++ b/src/main/java/nova/core/component/ComponentProvider.java
@@ -50,7 +50,7 @@ public abstract class ComponentProvider<CM extends ComponentMap> {
 	@SuppressWarnings("unchecked")
 	public <C extends ComponentMap> ComponentProvider(Class<C> componentsClass) {
 		this.components = (CM) InjectionUtil.newInstance(componentsClass,
-			clazz -> ComponentProvider.class == clazz ? Optional.of(this) : Optional.empty());
+			clazz -> clazz.isAssignableFrom(getClass()) ? Optional.of(this) : Optional.empty());
 	}
 
 	/**

--- a/src/main/java/nova/core/util/ArrayUtil.java
+++ b/src/main/java/nova/core/util/ArrayUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 NOVA, All rights reserved.
+ * Copyright (c) 2017 NOVA, All rights reserved.
  * This library is free software, licensed under GNU Lesser General Public License version 3
  *
  * This file is part of NOVA.
@@ -17,28 +17,31 @@
  * You should have received a copy of the GNU General Public License
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
  */
+package nova.core.util;
 
-package nova.core.component.exception;
-
-import nova.core.component.Component;
-import nova.core.util.ArrayUtil;
-import nova.core.util.exception.NovaException;
+import java.util.Arrays;
 
 /**
- * Exception thrown when an error to do with components occurs
+ * @author ExE Boss
  */
-public class ComponentException extends NovaException {
+public class ArrayUtil {
 
-	private static final long serialVersionUID = 2017_03_18L;
-
-	public Class<?> component;
-
-	public ComponentException(String message, Class<?> component, Object... parameters) {
-		super(message, ArrayUtil.join(component, parameters));
-		this.component = component;
+	public static <T> T[] join(T object, T[] array) {
+		T[] ret = Arrays.copyOf(array, array.length + 1);
+		System.arraycopy(array, 0, ret, 1, array.length);
+		ret[0] = object;
+		return ret;
 	}
 
-	public ComponentException(String message, Component component, Object... parameters) {
-		this(message, component.getClass(), parameters);
+	public static <T> T[] join(T[] array1, T[] array2) {
+		T[] ret = Arrays.copyOf(array1, array1.length + array2.length);
+		System.arraycopy(array2, 0, ret, array1.length, array2.length);
+		return ret;
+	}
+
+	public static <T> T[] join(T[] array, T object) {
+		T[] ret = Arrays.copyOf(array, array.length + 1);
+		ret[array.length] = object;
+		return ret;
 	}
 }

--- a/src/test/java/nova/core/component/exception/ComponentExceptionTest.java
+++ b/src/test/java/nova/core/component/exception/ComponentExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 NOVA, All rights reserved.
+ * Copyright (c) 2017 NOVA, All rights reserved.
  * This library is free software, licensed under GNU Lesser General Public License version 3
  *
  * This file is part of NOVA.
@@ -20,25 +20,24 @@
 
 package nova.core.component.exception;
 
-import nova.core.component.Component;
-import nova.core.util.ArrayUtil;
-import nova.core.util.exception.NovaException;
+import nova.core.component.Category;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Exception thrown when an error to do with components occurs
+ * @author ExE Boss
  */
-public class ComponentException extends NovaException {
+public class ComponentExceptionTest {
 
-	private static final long serialVersionUID = 2017_03_18L;
+	@Test
+	public void testComponentException() {
+		ComponentException ex = new ComponentException("Object %s is %s", Category.class, Object.class);
+		assertThat(ex.getMessage()).isEqualTo("Object " + Category.class + " is " + Object.class);
+		assertThat(ex.component).isEqualTo(Category.class);
 
-	public Class<?> component;
-
-	public ComponentException(String message, Class<?> component, Object... parameters) {
-		super(message, ArrayUtil.join(component, parameters));
-		this.component = component;
-	}
-
-	public ComponentException(String message, Component component, Object... parameters) {
-		this(message, component.getClass(), parameters);
+		ex = new ComponentException("Component %s is %s", new Category("Test"), Object.class);
+		assertThat(ex.getMessage()).isEqualTo("Component " + Category.class + " is " + Object.class);
+		assertThat(ex.component).isEqualTo(Category.class);
 	}
 }

--- a/src/test/java/nova/core/util/ArrayUtilTest.java
+++ b/src/test/java/nova/core/util/ArrayUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 NOVA, All rights reserved.
+ * Copyright (c) 2017 NOVA, All rights reserved.
  * This library is free software, licensed under GNU Lesser General Public License version 3
  *
  * This file is part of NOVA.
@@ -18,27 +18,27 @@
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package nova.core.component.exception;
+package nova.core.util;
 
-import nova.core.component.Component;
-import nova.core.util.ArrayUtil;
-import nova.core.util.exception.NovaException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Exception thrown when an error to do with components occurs
+ * @author ExE Boss
  */
-public class ComponentException extends NovaException {
+public class ArrayUtilTest {
 
-	private static final long serialVersionUID = 2017_03_18L;
-
-	public Class<?> component;
-
-	public ComponentException(String message, Class<?> component, Object... parameters) {
-		super(message, ArrayUtil.join(component, parameters));
-		this.component = component;
-	}
-
-	public ComponentException(String message, Component component, Object... parameters) {
-		this(message, component.getClass(), parameters);
+	@Test
+	public void testJoin() {
+		assertThat(ArrayUtil.join("foo", new String[]{"bar", "baz"}))
+			.hasSize(3)
+			.containsExactly("foo", "bar", "baz");
+		assertThat(ArrayUtil.join(new String[]{"foo", "bar"}, "baz"))
+			.hasSize(3)
+			.containsExactly("foo", "bar", "baz");
+		assertThat(ArrayUtil.join(new String[]{"foo", "bar"}, new String[]{"baz", "str"}))
+			.hasSize(4)
+			.containsExactly("foo", "bar", "baz", "str");
 	}
 }

--- a/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
+++ b/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
@@ -84,6 +84,7 @@ public class NovaLauncherTest extends AbstractNovaLauncherTest {
 		createLauncher(TestModWithMissingDependency.class);
 	}
 
+	@Test
 	public void testMissingOptionalDepencency() {
 		NovaLauncher launcher = createLauncher(TestModWithMissingOptionalDependency.class);
 		assertThat(launcher.getModClasses())


### PR DESCRIPTION
This PR fixes the ComponentException message constructed as such:
```java
throw new ComponentException("Issue with component %s on provider %s.", component, this);
```
getting logged as: `Issue with component Component on provider [[Ljava.lang.Object;@33d8e330].`
instead of as: `Issue with component Component on provider Provider.`

Also adds a missed `@Test` annotation to a method in `NovaLauncherTest`.