### PR TITLE
Implement Generic Type Resolution for Factory creation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compile 'org.slf4j:slf4j-api:1.7.10'
 	compile 'org.apache.commons:commons-math3:3.5'
 	compile 'javax.json:javax.json-api:1.0'
+	compile 'net.jodah:typetools:0.4.9'
 
 	runtime 'org.glassfish:javax.json:1.0.4'
 	testRuntime 'org.slf4j:slf4j-simple:1.7.10'

--- a/src/test/java/nova/core/util/registry/FactoryTest.java
+++ b/src/test/java/nova/core/util/registry/FactoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nova.core.util.registry;
+
+import nova.testutils.FakeObject;
+import nova.testutils.FakeObjectFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static nova.testutils.NovaAssertions.assertThat;
+
+/**
+ * @author ExE Boss
+ */
+public class FactoryTest {
+
+	private FakeObjectFactory factory;
+
+	@Before
+	public void setUp() {
+		this.factory = new FakeObjectFactory("id", FactoryTestObject::new);
+	}
+
+	@Test
+	public void testType() {
+		assertThat(this.factory.getType()).isEqualTo(FactoryTestObject.class);
+	}
+
+	public static class FactoryTestObject extends FakeObject {
+
+	}
+}

--- a/src/test/java/nova/testutils/FakeObject.java
+++ b/src/test/java/nova/testutils/FakeObject.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nova.testutils;
+
+import nova.core.component.exception.ComponentException;
+import nova.core.component.misc.FactoryProvider;
+import nova.core.util.Identifiable;
+
+/**
+ * @author ExE Boss
+ */
+public class FakeObject implements Identifiable {
+
+	private FakeObjectFactory factory = null;
+
+	void initFactory(FakeObjectFactory factory) {
+		if (this.factory == null) {
+			this.factory = factory;
+		} else {
+			throw new ComponentException("Attempt to add two components of the type %s to %s", FactoryProvider.class, this);
+		}
+	}
+
+	public final FakeObjectFactory getFactory() {
+		if (factory != null) {
+			return factory;
+		} else {
+			throw new ComponentException("Attempt to get component that does not exist: %s", FactoryProvider.class);
+		}
+	}
+
+	@Override
+	public String getID() {
+		return getFactory().getID();
+	}
+}

--- a/src/test/java/nova/testutils/FakeObjectFactory.java
+++ b/src/test/java/nova/testutils/FakeObjectFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nova.testutils;
+
+import nova.core.util.registry.Factory;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * @author ExE Boss
+ */
+public class FakeObjectFactory extends Factory<FakeObjectFactory, FakeObject> {
+
+	public FakeObjectFactory(String id, Class<? extends FakeObject> type, Function<FakeObject, FakeObject> processor, Function<Class<?>, Optional<?>> mapping) {
+		super(id, type, processor, mapping);
+	}
+
+	public FakeObjectFactory(String id, Class<? extends FakeObject> type, Function<FakeObject, FakeObject> processor) {
+		super(id, type, processor);
+	}
+
+	public FakeObjectFactory(String id, Class<? extends FakeObject> type) {
+		super(id, type);
+	}
+
+	public FakeObjectFactory(String id, Supplier<FakeObject> constructor, Function<FakeObject, FakeObject> processor) {
+		super(id, constructor, processor);
+	}
+
+	public FakeObjectFactory(String id, Supplier<FakeObject> constructor) {
+		super(id, constructor);
+	}
+
+	@Override
+	protected FakeObjectFactory selfConstructor(String id, Supplier<FakeObject> constructor, Function<FakeObject, FakeObject> processor) {
+		return new FakeObjectFactory(id, constructor, processor);
+	}
+}


### PR DESCRIPTION
See #292 for details.

### To do list:
- [ ] Search for and replace `Factory.build().getClass()` calls with `Factory.getType()` calls.

---

Resolves #292