### PR TITLE
Mod specific logger is passed the mod's name instead of the class name

### DIFF
--- a/src/main/java/nova/internal/core/di/LoggerModule.java
+++ b/src/main/java/nova/internal/core/di/LoggerModule.java
@@ -73,7 +73,8 @@ public class LoggerModule extends BinderModule {
 					.map(target -> target.getTarget().getInstance().getType().getRawType())
 					.filter(clazz -> clazz.isAnnotationPresent(Mod.class))
 					.findFirst()
-					.map(clazz -> LoggerFactory.getLogger(clazz.getAnnotation(Mod.class).name()))
+					.map(clazz -> clazz.getAnnotation(Mod.class))
+					.map(mod -> LoggerFactory.getLogger(String.format("%s (%s)", mod.id(), mod.name())))
 					.orElseGet(() -> LoggerFactory.getLogger(dependency.iterator().next().getTarget().getInstance().getType().getRawType()));
 			}
 		}

--- a/src/main/java/nova/internal/core/util/InjectionUtil.java
+++ b/src/main/java/nova/internal/core/util/InjectionUtil.java
@@ -216,7 +216,7 @@ public class InjectionUtil {
 			.max(Comparator.comparingInt((constructor) -> constructor.getParameterTypes().length)).get();
 
 		Object[] parameters = Arrays.stream(cons.getParameterTypes())
-			.map(clazz -> ((Optional<Object>) mapping.apply(clazz)).orElseGet(() -> Game.injector().resolve(Dependency.dependency(clazz))))
+			.map(clazz -> ((Optional<Object>) mapping.apply(clazz)).orElseGet(() -> Game.injector().resolve(Dependency.dependency(clazz).injectingInto(classToConstruct))))
 			.collect(Collectors.toList()).toArray();
 
 		try {

--- a/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
+++ b/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
@@ -24,6 +24,7 @@ import nova.internal.core.Game;
 import nova.internal.core.bootstrap.DependencyInjectionEntryPoint;
 import nova.testutils.mod.TestMod;
 import nova.testutils.mod.TestModDuplicate;
+import nova.testutils.mod.TestModWithLogger;
 import nova.testutils.mod.TestModWithMismatchedDependency;
 import nova.testutils.mod.TestModWithMismatchedDependencyPattern;
 import nova.testutils.mod.TestModWithMissingDependency;
@@ -99,5 +100,10 @@ public class NovaLauncherTest extends AbstractNovaLauncherTest {
 	@Test(expected = InitializationException.class)
 	public void testDuplicateModIDs() {
 		createLauncher(TestMod.class, TestModDuplicate.class);
+	}
+
+	@Test
+	public void testModLogger() {
+		createLauncher(TestModWithLogger.class);
 	}
 }

--- a/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
+++ b/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
@@ -85,6 +85,7 @@ public class NovaLauncherTest extends AbstractNovaLauncherTest {
 		createLauncher(TestModWithMissingDependency.class);
 	}
 
+	@Test
 	public void testMissingOptionalDepencency() {
 		NovaLauncher launcher = createLauncher(TestModWithMissingOptionalDependency.class);
 		assertThat(launcher.getModClasses())

--- a/src/test/java/nova/testutils/mod/TestModWithLogger.java
+++ b/src/test/java/nova/testutils/mod/TestModWithLogger.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.testutils.mod;
+
+import nova.core.loader.Mod;
+import org.slf4j.Logger;
+
+/**
+ * @author ExE Boss
+ */
+@Mod(id = "testModWithLogger", name = "Test Mod With Logger", version = "0.0.1", novaVersion = "0.1.0")
+public class TestModWithLogger {
+
+	public TestModWithLogger(Logger logger) {
+		logger.info("Hello World! from Test Mod With Logger");
+	}
+}

--- a/src/test/java/nova/testutils/mod/TestModWithLogger.java
+++ b/src/test/java/nova/testutils/mod/TestModWithLogger.java
@@ -22,13 +22,20 @@ package nova.testutils.mod;
 import nova.core.loader.Mod;
 import org.slf4j.Logger;
 
+import static nova.testutils.NovaAssertions.assertThat;
+
 /**
  * @author ExE Boss
  */
-@Mod(id = "testModWithLogger", name = "Test Mod With Logger", version = "0.0.1", novaVersion = "0.1.0")
+@Mod(id = TestModWithLogger.MOD_ID, name = TestModWithLogger.NAME, version = TestModWithLogger.VERSION, novaVersion = "0.1.0")
 public class TestModWithLogger {
 
+	public static final String MOD_ID = "testModWithLogger";
+	public static final String NAME = "Test Mod With Logger";
+	public static final String VERSION = "0.1.0";
+
 	public TestModWithLogger(Logger logger) {
-		logger.info("Hello World! from Test Mod With Logger");
+		assertThat(logger.getName()).isEqualTo(MOD_ID + " (" + NAME + ')');
+		logger.info("Hello World!");
 	}
 }


### PR DESCRIPTION
### Completed:
- [x] Supply target information to the `Dependency` parameter in `LoggerModule.LoggerSupplier.supply(Dependency, Injector)`
- [x] Decide if the mod id should also be shown in the logs.
    - Mod id is now shown in the logs.
