### PR TITLE
Fix Translatable class name typo

### DIFF
--- a/src/main/java/nova/core/block/Block.java
+++ b/src/main/java/nova/core/block/Block.java
@@ -30,7 +30,7 @@ import nova.core.event.bus.Event;
 import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.language.LanguageManager;
-import nova.core.language.Translateable;
+import nova.core.language.Translatable;
 import nova.core.util.Direction;
 import nova.core.util.Identifiable;
 import nova.core.world.World;
@@ -45,7 +45,7 @@ import java.util.Set;
 /**
  * @author Calclavia
  */
-public class Block extends SidedComponentProvider implements Identifiable, Translateable {
+public class Block extends SidedComponentProvider implements Identifiable, Translatable {
 
 	public ItemFactory getItemFactory() {
 		return Game.items().getItemFromBlock(getFactory());

--- a/src/main/java/nova/core/block/BlockFactory.java
+++ b/src/main/java/nova/core/block/BlockFactory.java
@@ -23,7 +23,7 @@ package nova.core.block;
 import nova.core.component.misc.FactoryProvider;
 import nova.core.item.ItemBlock;
 import nova.core.language.LanguageManager;
-import nova.core.language.Translateable;
+import nova.core.language.Translatable;
 import nova.core.util.registry.Factory;
 import nova.internal.core.Game;
 
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
  * The factory type for blocks.
  * @author Calclavia
  */
-public class BlockFactory extends Factory<BlockFactory, Block> implements Translateable {
+public class BlockFactory extends Factory<BlockFactory, Block> implements Translatable {
 
 	final Consumer<BlockFactory> postRegister;
 	private String unlocalizedName;

--- a/src/main/java/nova/core/item/Item.java
+++ b/src/main/java/nova/core/item/Item.java
@@ -26,7 +26,7 @@ import nova.core.component.misc.FactoryProvider;
 import nova.core.entity.Entity;
 import nova.core.event.bus.Event;
 import nova.core.language.LanguageManager;
-import nova.core.language.Translateable;
+import nova.core.language.Translatable;
 import nova.core.render.Color;
 import nova.core.retention.Storable;
 import nova.core.util.Direction;
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 //TODO: This Storable implementation is flawed and not based on ID.
-public class Item extends ComponentProvider<ComponentMap> implements Identifiable, Storable, Cloneable, Translateable {
+public class Item extends ComponentProvider<ComponentMap> implements Identifiable, Storable, Cloneable, Translatable {
 
 	/**
 	 * The amount of this item that is present.

--- a/src/main/java/nova/core/item/ItemFactory.java
+++ b/src/main/java/nova/core/item/ItemFactory.java
@@ -22,7 +22,7 @@ package nova.core.item;
 
 import nova.core.component.misc.FactoryProvider;
 import nova.core.language.LanguageManager;
-import nova.core.language.Translateable;
+import nova.core.language.Translatable;
 import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.Identifiable;
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 /**
  * @author Calclavia
  */
-public class ItemFactory extends Factory<ItemFactory, Item> implements Identifiable, Translateable {
+public class ItemFactory extends Factory<ItemFactory, Item> implements Identifiable, Translatable {
 	private String unlocalizedName;
 
 	public ItemFactory(String id, Class<? extends Item> type, Function<Item, Item> processor, Function<Class<?>, Optional<?>> mapping) {

--- a/src/main/java/nova/core/language/Translatable.java
+++ b/src/main/java/nova/core/language/Translatable.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @author ExE Boss
  */
-public interface Translateable {
+public interface Translatable {
 
 	/**
 	 * Gets the unlocalized name of this object.
@@ -65,8 +65,8 @@ public interface Translateable {
 				Object value = field.get(this);
 				if (value instanceof Optional)
 					value = ((Optional<?>) value).map(o -> (Object) o).orElse("empty");
-				if (value instanceof Translateable)
-					replacements.put(key, ((Translateable) value).getLocalizedName());
+				if (value instanceof Translatable)
+					replacements.put(key, ((Translatable) value).getLocalizedName());
 				else
 					replacements.put(key, Objects.toString(value));
 				field.setAccessible(false);

--- a/src/main/java/nova/core/language/Translate.java
+++ b/src/main/java/nova/core/language/Translate.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 /**
  * Fields annotated with this annotation declare that they
  * should be used as replacement parameters during translation
- * of {@link Translateable} types.
+ * of {@link Translatable} types.
  *
  * @author ExE Boss
  */

--- a/src/test/java/nova/core/language/TranslatableTest.java
+++ b/src/test/java/nova/core/language/TranslatableTest.java
@@ -31,15 +31,15 @@ import static nova.testutils.NovaAssertions.assertThat;
 /**
  * @author ExE Boss
  */
-public class TranslateableTest {
+public class TranslatableTest {
 
 	LanguageManager languageManager;
-	TranslateableImpl translateable;
+	TranslatableImpl translateable;
 
 	@Before
 	public void setUp() {
 		languageManager = new FakeLanguageManager();
-		translateable = new TranslateableImpl();
+		translateable = new TranslatableImpl();
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class TranslateableTest {
 			.containsEntry("emptyStr", "empty");
 	}
 
-	public class TranslateableImpl implements Translateable {
+	public class TranslatableImpl implements Translatable {
 
 		@Translate
 		public final String key1 = "42";
@@ -74,7 +74,7 @@ public class TranslateableTest {
 		public final String key2 = "24";
 
 		@Translate
-		public final TranslateableOtherImpl other = new TranslateableOtherImpl();
+		public final TranslatableOtherImpl other = new TranslatableOtherImpl();
 
 		@Override
 		public String getUnlocalizedName() {
@@ -87,7 +87,7 @@ public class TranslateableTest {
 		}
 	}
 
-	public class TranslateableOtherImpl implements Translateable {
+	public class TranslatableOtherImpl implements Translatable {
 
 		@Translate
 		public final Optional<String> filledStr = Optional.of("String");


### PR DESCRIPTION
As it turns out, the correct spelling is `Translatable` instead of `Translateable`, so I had it right the first time.