### PR TITLE
Fix NOVA Core language files not loading

### DIFF
--- a/minecraft/1.7/build.gradle
+++ b/minecraft/1.7/build.gradle
@@ -128,6 +128,11 @@ processResources {
 	}
 
 	from(sourceSets.main.resources.srcDirs) {
-		exclude 'mcmod.info', 'fmlbranding.properties'
+		exclude 'mcmod.info', 'fmlbranding.properties', 'assets/*/lang/*'
+	}
+
+	// TODO: Merge Core and Wrapper language files.
+	from(rootProject.sourceSets.main.resources.srcDirs) {
+		include 'assets/*/lang/*'
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ClientProxy.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ClientProxy.java
@@ -81,7 +81,7 @@ public class ClientProxy extends CommonProxy {
 		languages.stream()
 			.map(lang -> lang.getLanguageCode().replace('_', '-'))
 			.forEach(langName -> {
-				ResourceLocation location = new ResourceLocation(NovaMinecraft.id, langName + ".lang");
+				ResourceLocation location = new ResourceLocation("nova", "lang/" + langName + ".lang");
 				try {
 					Minecraft.getMinecraft().getResourceManager().getAllResources(location).forEach(resource ->
 						loadLanguage(languageManager, langName, ((IResource)resource).getInputStream()));

--- a/minecraft/1.8/build.gradle
+++ b/minecraft/1.8/build.gradle
@@ -129,6 +129,11 @@ processResources {
 	}
 
 	from(sourceSets.main.resources.srcDirs) {
-		exclude 'mcmod.info', 'fmlbranding.properties'
+		exclude 'mcmod.info', 'fmlbranding.properties', 'assets/*/lang/*'
+	}
+
+	// TODO: Merge Core and Wrapper language files.
+	from(rootProject.sourceSets.main.resources.srcDirs) {
+		include 'assets/*/lang/*'
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ClientProxy.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ClientProxy.java
@@ -90,7 +90,7 @@ public class ClientProxy extends CommonProxy {
 		languages.stream()
 			.map(lang -> lang.getLanguageCode().replace('_', '-'))
 			.forEach(langName -> {
-				ResourceLocation location = new ResourceLocation("nova", langName + ".lang");
+				ResourceLocation location = new ResourceLocation("nova", "lang/" + langName + ".lang");
 				try {
 					Minecraft.getMinecraft().getResourceManager().getAllResources(location).forEach(resource ->
 						loadLanguage(languageManager, langName, ((IResource)resource).getInputStream()));


### PR DESCRIPTION
If a wrapper also defines a language file, then it will be ignored currently.

The Core and Wrapper language files should instead be merged, with the Wrapper language file contents following the Core language file contents, replacing Core lines where the Core and Wrapper language file key is equal.

### To do list:
- [ ] Make the build script merge Core and Wrapper language files.

---

Ex. the following files should be merged like so:
#### Core `some.lang`:
```properties
core.foo=Core Foo
core.bar=Core Bar
core.baz=Core Baz
```

#### Wrapper `some.lang`:
(placement of `core.bar` is irrelevant)
```properties
wrapper.foo=Wrapper Foo
wrapper.bar=Wrapper Bar
wrapper.baz=Wrapper Baz
core.bar=Replaced Bar
```

#### Merged `some.lang`:
```properties
core.foo=Core Foo
core.bar=Replaced Bar
core.baz=Core Baz

wrapper.foo=Wrapper Foo
wrapper.bar=Wrapper Bar
wrapper.baz=Wrapper Baz
```