### PR TITLE
Show NOVA logging messages in Minecraft logs

### DIFF
--- a/minecraft/1.7/build.gradle
+++ b/minecraft/1.7/build.gradle
@@ -10,10 +10,14 @@ archivesBaseName = "NOVA-Core-Wrapper-MC1.7"
 configurations {
 	fatJar
 	compile.extendsFrom fatJar
+	// Exclude slf4j-log4j from tests (we use slf4j-simple)
+	testRuntime.exclude module: 'slf4j-log4j12'
+	testRuntime.exclude module: 'log4j-slf4j-impl'
 }
 
 dependencies {
 	fatJar project(":")
+	fatJar 'org.apache.logging.log4j:log4j-slf4j-impl:2.0-beta9'
 	testCompile project(path: ':', configuration: 'wrapperTests')
 
 	testCompile "junit:junit:4.12"

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/NovaMinecraftPreloader.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/NovaMinecraftPreloader.java
@@ -44,6 +44,7 @@ import nova.core.wrapper.mc.forge.v17.util.ReflectionUtil;
 import nova.core.wrapper.mc.forge.v17.wrapper.assets.NovaFileResourcePack;
 import nova.core.wrapper.mc.forge.v17.wrapper.assets.NovaFolderResourcePack;
 import nova.core.wrapper.mc.forge.v17.wrapper.assets.NovaResourcePack;
+import nova.internal.core.Game;
 
 import java.io.File;
 import java.io.IOException;
@@ -240,7 +241,7 @@ public class NovaMinecraftPreloader extends DummyModContainer {
 			@SuppressWarnings("unchecked")
 			Set<String> classLoaderExceptions = (Set<String>) setField.get(classLoader);
 			classLoaderExceptions.remove("org.apache.");
-			System.out.println("Successfully hacked 'org.apache' out of launcher exclusion");
+			Game.logger().info("Successfully hacked 'org.apache' out of launcher exclusion");
 		} catch (Exception e) {
 			throw new ClassLoaderUtil.ClassLoaderException(e);
 		}
@@ -321,7 +322,7 @@ public class NovaMinecraftPreloader extends DummyModContainer {
 						NovaFileResourcePack pack = new NovaFileResourcePack(file, novaMod.id(), novaMod.domains());
 						packs.add(pack);
 						novaPacks.add(pack);
-						System.out.println("Registered NOVA jar resource pack: " + fn);
+						Game.logger().info("Registered NOVA jar resource pack: {}", fn);
 					}
 				} else {
 					//Add folder resource pack location. The folderLocation is the root of the project, including the packages of classes, and an assets folder inside.
@@ -340,7 +341,7 @@ public class NovaMinecraftPreloader extends DummyModContainer {
 					NovaFolderResourcePack pack = new NovaFolderResourcePack(folderFile, novaMod.id(), novaMod.domains());
 					packs.add(pack);
 					novaPacks.add(pack);
-					System.out.println("Registered NOVA folder resource pack: " + folderFile.getAbsolutePath());
+					Game.logger().info("Registered NOVA folder resource pack: {}", folderFile.getAbsolutePath());
 				}
 			});
 			resourcePackField.set(FMLClientHandler.instance(), packs);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ASMHelper.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ASMHelper.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v17.asm.lib;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.launchwrapper.LaunchClassLoader;
+import nova.internal.core.Game;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
@@ -134,7 +135,7 @@ public class ASMHelper {
 				if (method == null) {
 					throw new RuntimeException("Method not found: " + injector.method);
 				}
-				System.out.println("Injecting into " + injector.method + "\n" + printInsnList(injector.injection));
+				Game.logger().info("Injecting into {}\n", injector.method, printInsnList(injector.injection));
 
 				List<AbstractInsnNode> callNodes;
 				if (injector.before) {
@@ -149,10 +150,10 @@ public class ASMHelper {
 
 				for (AbstractInsnNode node : callNodes) {
 					if (injector.before) {
-						System.out.println("Injected before: " + printInsn(node));
+						Game.logger().info("Injected before: {}", printInsn(node));
 						method.instructions.insertBefore(node, cloneInsnList(injector.injection));
 					} else {
-						System.out.println("Injected after: " + printInsn(node));
+						Game.logger().info("Injected after: {}", printInsn(node));
 						method.instructions.insert(node, cloneInsnList(injector.injection));
 					}
 				}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ComponentInjector.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ComponentInjector.java
@@ -26,6 +26,7 @@ import nova.core.component.ComponentProvider;
 import nova.core.component.Passthrough;
 import nova.core.network.NetworkTarget.Side;
 import nova.core.util.ClassLoaderUtil;
+import nova.internal.core.Game;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -70,7 +71,7 @@ public class ComponentInjector<T> implements Opcodes {
 
 			if (components.size() > 0) {
 				List<Class<? extends Component>> componentClazzes = components.stream().map(c -> c.getClass()).collect(Collectors.toList());
-				System.out.println(Side.get() + " " + componentClazzes);
+				Game.logger().info("{} {}", Side.get(), componentClazzes);
 				if (cache.containsKey(componentClazzes))
 				// Cached class
 				{

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/ChunkTransformer.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/ChunkTransformer.java
@@ -22,6 +22,7 @@ package nova.core.wrapper.mc.forge.v17.asm.transformers;
 
 import nova.core.wrapper.mc.forge.v17.asm.lib.ASMHelper;
 import nova.core.wrapper.mc.forge.v17.asm.lib.ObfMapping;
+import nova.internal.core.Game;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
@@ -35,23 +36,23 @@ public class ChunkTransformer implements Transformer {
 
 	@Override
 	public void transform(ClassNode cnode) {
-		System.out.println("[NOVA] Transforming Chunk class for chunkModified event.");
+		Game.logger().info("Transforming Chunk class for chunkModified event.");
 
 		ObfMapping obfMap = new ObfMapping("apx", "a", "(IIILaji;I)Z");
-		ObfMapping srgMap = new ObfMapping("net/minecraft/world/chunk/Chunk", "func_150807_a", "(IIILnet/minecraft/block/Block;I)Z");
+		ObfMapping deobfMap = new ObfMapping("net/minecraft/world/chunk/Chunk", "func_150807_a", "(IIILnet/minecraft/block/Block;I)Z");
 
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
-			method = ASMHelper.findMethod(srgMap, cnode);
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
+			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
-				System.out.println("[NOVA] Lookup " + srgMap + " failed!");
+				throw new IllegalStateException("[NOVA] Lookup " + deobfMap + " failed!");
 			}
 		}
 
-		System.out.println("[NOVA] Found method " + method.name);
+		Game.logger().info("Found method {}", method.name);
 
 		InsnList list = new InsnList();
 		list.add(new VarInsnNode(ALOAD, 0));
@@ -75,6 +76,6 @@ public class ChunkTransformer implements Transformer {
 			method.instructions.insert(list);
 		}
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/GameDataTransformer.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/GameDataTransformer.java
@@ -21,6 +21,7 @@ package nova.core.wrapper.mc.forge.v17.asm.transformers;
 
 import nova.core.wrapper.mc.forge.v17.asm.lib.ASMHelper;
 import nova.core.wrapper.mc.forge.v17.asm.lib.ObfMapping;
+import nova.internal.core.Game;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.JumpInsnNode;
@@ -35,7 +36,7 @@ public class GameDataTransformer implements Transformer {
 
 	@Override
 	public void transform(ClassNode cnode) {
-		System.out.println("[NOVA] Transforming GameData class for correct NOVA mod id mapping.");
+		Game.logger().info("Transforming GameData class for correct NOVA mod id mapping.");
 		transformAddPrefix(cnode);
 		transformRegisterBlock(cnode);
 		transformRegisterItem(cnode);
@@ -49,7 +50,7 @@ public class GameDataTransformer implements Transformer {
 			throw new IllegalStateException("[NOVA] Lookup " + mapping + " failed!");
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		@SuppressWarnings("unchecked")
 		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(49);
@@ -61,7 +62,7 @@ public class GameDataTransformer implements Transformer {
 
 		method.instructions.insert(prev, list);
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 
 	private void transformRegisterBlock(ClassNode cnode) {
@@ -71,7 +72,7 @@ public class GameDataTransformer implements Transformer {
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
 			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
@@ -79,7 +80,7 @@ public class GameDataTransformer implements Transformer {
 			}
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		@SuppressWarnings("unchecked")
 		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(12);
@@ -91,7 +92,7 @@ public class GameDataTransformer implements Transformer {
 
 		method.instructions.insert(prev, list);
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 
 	private void transformRegisterItem(ClassNode cnode) {
@@ -101,7 +102,7 @@ public class GameDataTransformer implements Transformer {
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
 			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
@@ -109,7 +110,7 @@ public class GameDataTransformer implements Transformer {
 			}
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		@SuppressWarnings("unchecked")
 		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(12);
@@ -121,6 +122,6 @@ public class GameDataTransformer implements Transformer {
 
 		method.instructions.insert(prev, list);
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/TileEntityTransformer.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/transformers/TileEntityTransformer.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v17.asm.transformers;
 import nova.core.wrapper.mc.forge.v17.asm.lib.ASMHelper;
 import nova.core.wrapper.mc.forge.v17.asm.lib.InstructionComparator;
 import nova.core.wrapper.mc.forge.v17.asm.lib.ObfMapping;
+import nova.internal.core.Game;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.MethodInsnNode;
@@ -34,7 +35,7 @@ public class TileEntityTransformer implements Transformer {
 	@Override
 	public void transform(ClassNode cnode) {
 
-		System.out.println("[NOVA] Transforming TileEntity class for dynamic instance injection.");
+		Game.logger().info("Transforming TileEntity class for dynamic instance injection.");
 
 		ObfMapping obfMap = new ObfMapping("aor", "c", "(Ldh;)Laor;");
 		ObfMapping deobfMap = new ObfMapping("net/minecraft/tileentity/TileEntity", "createAndLoadEntity", "(Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/tileentity/TileEntity;");
@@ -42,15 +43,15 @@ public class TileEntityTransformer implements Transformer {
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
 			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
-				System.out.println("[NOVA] Lookup " + deobfMap + " failed!");
+				throw new IllegalStateException("[NOVA] Lookup " + deobfMap + " failed!");
 			}
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		ASMHelper.removeBlock(method.instructions, new InstructionComparator.InsnListSection(method.instructions, 23, 26));
 
@@ -61,5 +62,7 @@ public class TileEntityTransformer implements Transformer {
 		list.add(new VarInsnNode(ASTORE, 1));
 
 		method.instructions.insert(method.instructions.get(22), list);
+
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/NovaMinecraft.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/NovaMinecraft.java
@@ -204,7 +204,7 @@ public class NovaMinecraft {
 			FMLCommonHandler.instance().bus().register(new FMLEventHandler());
 			MinecraftForge.EVENT_BUS.register(Game.retention());
 		} catch (Exception e) {
-			System.out.println("Error during preInit");
+			Game.logger().error("Error during preInit", e);
 			e.printStackTrace();
 			throw new InitializationException(e);
 		}
@@ -228,7 +228,7 @@ public class NovaMinecraft {
 			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
-			System.out.println("Error during init");
+			Game.logger().error("Error during init", e);
 			e.printStackTrace();
 			throw new InitializationException(e);
 		}
@@ -253,7 +253,7 @@ public class NovaMinecraft {
 			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
-			System.out.println("Error during postInit");
+			Game.logger().error("Error during postInit", e);
 			e.printStackTrace();
 			throw new InitializationException(e);
 		}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/MCRetentionManager.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/MCRetentionManager.java
@@ -87,7 +87,7 @@ public class MCRetentionManager extends RetentionManager {
 			tempFile.renameTo(file);
 			return true;
 		} catch (Exception e) {
-			System.out.println("Failed to queueSave " + file.getName() + ".dat!");
+			Game.logger().error("Failed to queueSave {}!", file.getName(), e);
 			e.printStackTrace();
 			return false;
 		}
@@ -109,7 +109,7 @@ public class MCRetentionManager extends RetentionManager {
 				return new NBTTagCompound();
 			}
 		} catch (Exception e) {
-			System.out.println("Failed to load " + file.getName() + ".dat!");
+			Game.logger().error("Failed to load {}!", file.getName(), e);
 			e.printStackTrace();
 			return null;
 		}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/ReflectionUtil.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/ReflectionUtil.java
@@ -40,6 +40,7 @@ import net.minecraftforge.common.ChestGenHooks;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
+import nova.internal.core.Game;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -147,7 +148,7 @@ public class ReflectionUtil {
 		try {
 			return (List<ArrayList<ItemStack>>) OREDICTIONARY_IDTOSTACK.get(null);
 		} catch (IllegalAccessException ex) {
-			logError("ERROR - could not load ore dictionary stacks!");
+			Game.logger().error("ERROR - could not load ore dictionary stacks!");
 			return null;
 		}
 	}
@@ -156,7 +157,7 @@ public class ReflectionUtil {
 		try {
 			return (List<ArrayList<ItemStack>>) OREDICTIONARY_IDTOSTACKUN.get(null);
 		} catch (IllegalAccessException ex) {
-			logError("ERROR - could not load ore dictionary stacks!");
+			Game.logger().error("ERROR - could not load ore dictionary stacks!");
 			return null;
 		}
 	}
@@ -165,7 +166,7 @@ public class ReflectionUtil {
 		try {
 			return (File) MINECRAFTSERVER_ANVILFILE.get(server);
 		} catch (IllegalAccessException ex) {
-			logError("could not load anvil file!");
+			Game.logger().error("could not load anvil file!");
 			return null;
 		}
 	}
@@ -187,7 +188,7 @@ public class ReflectionUtil {
 		try {
 			return SHAPEDORERECIPE_WIDTH.getInt(recipe);
 		} catch (IllegalAccessException ex) {
-			logError("could not load shaped ore recipe width!");
+			Game.logger().error("could not load shaped ore recipe width!");
 			return 3;
 		}
 	}
@@ -196,7 +197,7 @@ public class ReflectionUtil {
 		try {
 			return (Container) INVENTORYCRAFTING_EVENTHANDLER.get(inventory);
 		} catch (IllegalAccessException ex) {
-			logError("could not get inventory eventhandler");
+			Game.logger().error("could not get inventory eventhandler");
 			return null;
 		}
 	}
@@ -205,7 +206,7 @@ public class ReflectionUtil {
 		try {
 			return (EntityPlayer) SLOTCRAFTING_PLAYER.get(slot);
 		} catch (IllegalAccessException ex) {
-			logError("could not get inventory eventhandler");
+			Game.logger().error("could not get inventory eventhandler");
 			return null;
 		}
 	}
@@ -215,7 +216,7 @@ public class ReflectionUtil {
 			Field field = getField(StringTranslate.class, ObfuscationConstants.STRINGTRANSLATE_INSTANCE);
 			return (StringTranslate) field.get(null);
 		} catch (IllegalAccessException ex) {
-			logError("could not get string translator");
+			Game.logger().error("could not get string translator");
 			return null;
 		}
 	}
@@ -224,7 +225,7 @@ public class ReflectionUtil {
 		try {
 			return (ItemStack) SEEDENTRY_SEED.get(entry);
 		} catch (IllegalAccessException ex) {
-			logError("could not get SeedEntry seed");
+			Game.logger().error("could not get SeedEntry seed");
 			return null;
 		}
 	}
@@ -234,7 +235,7 @@ public class ReflectionUtil {
 			CraftingManager.getInstance(),
 			craftingRecipeList,
 			ObfuscationConstants.CRAFTINGMANAGER_RECIPES)) {
-			logError("could not set crafting recipe list");
+			Game.logger().error("could not set crafting recipe list");
 		}
 	}
 
@@ -242,15 +243,15 @@ public class ReflectionUtil {
 		try {
 			return SEEDENTRY_CONSTRUCTOR.newInstance(MineTweakerMC.getItemStack(stack.getStack()), (int) stack.getChance());
 		} catch (InstantiationException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		} catch (IllegalAccessException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		} catch (IllegalArgumentException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		} catch (InvocationTargetException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		}
-		
+
 		return null;
 	}*/
 
@@ -319,9 +320,5 @@ public class ReflectionUtil {
 		}
 
 		return null;
-	}
-
-	private static void logError(String message) {
-		System.out.println("ERROR: " + message);
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
@@ -147,6 +147,6 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 			blockWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, blockWrapper));
 		}
 
-		System.out.println("[NOVA]: Registered '" + blockFactory.getID() + "' block.");
+		Game.logger().info("Registered block: {}", blockFactory.getID());
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
@@ -143,7 +143,7 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 				return tileWrapper.getBlock();
 			}
 
-			System.out.println("Error: Block in TileWrapper is null.");
+			Game.logger().error("Error: Block in TileWrapper is null.");
 		}
 		return getBlockInstance((nova.core.world.World) Game.natives().toNova(access), position);
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
@@ -218,7 +218,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 				itemWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, itemWrapper));
 			}
 
-			System.out.println("[NOVA]: Registered '" + itemFactory.getID() + "' item.");
+			Game.logger().info("Registered item: {}", itemFactory.getID());
 		}
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/recipes/MinecraftRecipeRegistry.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/recipes/MinecraftRecipeRegistry.java
@@ -78,7 +78,7 @@ public class MinecraftRecipeRegistry {
 
 		ReflectionUtil.setCraftingRecipeList(new RecipeListWrapper(recipes));
 
-		System.out.println("Initialized recipes in " + (System.currentTimeMillis() - startTime) + " ms");
+		Game.logger().info("Initialized recipes in {} ms", (System.currentTimeMillis() - startTime));
 
 		recipeManager.whenRecipeAdded(CraftingRecipe.class, this::onNOVARecipeAdded);
 		recipeManager.whenRecipeRemoved(CraftingRecipe.class, this::onNOVARecipeRemoved);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/recipes/backward/MCCraftingGrid.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/recipes/backward/MCCraftingGrid.java
@@ -132,7 +132,7 @@ public class MCCraftingGrid implements CraftingGrid {
 
 		for (int i = 0; i < inventory.getSizeInventory(); i++) {
 			if (changed(i)) {
-				//System.out.println("Slot " + i + " changed");
+				//Game.logger().info("Slot {} changed", i);
 				original[i] = inventory.getStackInSlot(i);
 				if (inventory.getStackInSlot(i) != null) {
 					if (items[i] == null) {
@@ -149,7 +149,7 @@ public class MCCraftingGrid implements CraftingGrid {
 				}
 			}
 		}
-		//System.out.println("Num stack count: " + itemCount);
+		//Game.logger().info("Num stack count: {}", itemCount);
 	}
 
 	@Override
@@ -189,7 +189,7 @@ public class MCCraftingGrid implements CraftingGrid {
 
 	@Override
 	public boolean setCrafting(int x, int y, Optional<nova.core.item.Item> item) {
-		//System.out.println("SetStack(" + x + ", " + y + ") " + item);
+		//Game.logger().info("setCrafting({}, {}) {}", x, y, item);
 
 		int ix = y * width + x;
 		if (item.isPresent()) {
@@ -213,7 +213,7 @@ public class MCCraftingGrid implements CraftingGrid {
 
 	@Override
 	public boolean setCrafting(int i, Optional<nova.core.item.Item> item) {
-		//System.out.println("SetStack(" + i + ") " + item);
+		//Game.logger().info("setCrafting({}) {}", i, item);
 
 		if (item.isPresent()) {
 			if (items[i] == null) {

--- a/minecraft/1.8/build.gradle
+++ b/minecraft/1.8/build.gradle
@@ -10,10 +10,14 @@ archivesBaseName = "NOVA-Core-Wrapper-MC1.8"
 configurations {
 	fatJar
 	compile.extendsFrom fatJar
+	// Exclude slf4j-log4j from tests (we use slf4j-simple)
+	testRuntime.exclude module: 'slf4j-log4j12'
+	testRuntime.exclude module: 'log4j-slf4j-impl'
 }
 
 dependencies {
 	fatJar project(":")
+	fatJar 'org.apache.logging.log4j:log4j-slf4j-impl:2.0-beta9'
 	testCompile project(path: ':', configuration: 'wrapperTests')
 
 	testCompile "junit:junit:4.12"

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/NovaMinecraftPreloader.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/NovaMinecraftPreloader.java
@@ -44,6 +44,7 @@ import nova.core.wrapper.mc.forge.v18.util.ReflectionUtil;
 import nova.core.wrapper.mc.forge.v18.wrapper.assets.NovaFileResourcePack;
 import nova.core.wrapper.mc.forge.v18.wrapper.assets.NovaFolderResourcePack;
 import nova.core.wrapper.mc.forge.v18.wrapper.assets.NovaResourcePack;
+import nova.internal.core.Game;
 
 import java.io.File;
 import java.io.IOException;
@@ -241,7 +242,7 @@ public class NovaMinecraftPreloader extends DummyModContainer {
 			@SuppressWarnings("unchecked")
 			Set<String> classLoaderExceptions = (Set<String>) setField.get(classLoader);
 			classLoaderExceptions.remove("org.apache.");
-			System.out.println("Successfully hacked 'org.apache' out of launcher exclusion");
+			Game.logger().info("Successfully hacked 'org.apache' out of launcher exclusion");
 		} catch (Exception e) {
 			throw new ClassLoaderUtil.ClassLoaderException(e);
 		}
@@ -323,7 +324,7 @@ public class NovaMinecraftPreloader extends DummyModContainer {
 						NovaFileResourcePack pack = new NovaFileResourcePack(file, novaMod.id(), novaMod.domains());
 						packs.add(pack);
 						novaPacks.add(pack);
-						System.out.println("Registered NOVA jar resource pack: " + fn);
+						Game.logger().info("Registered NOVA jar resource pack: {}", fn);
 					}
 				} else {
 					//Add folder resource pack location. The folderLocation is the root of the project, including the packages of classes, and an assets folder inside.
@@ -342,7 +343,7 @@ public class NovaMinecraftPreloader extends DummyModContainer {
 					NovaFolderResourcePack pack = new NovaFolderResourcePack(folderFile, novaMod.id(), novaMod.domains());
 					packs.add(pack);
 					novaPacks.add(pack);
-					System.out.println("Registered NOVA folder resource pack: " + folderFile.getAbsolutePath());
+					Game.logger().info("Registered NOVA folder resource pack: {}", folderFile.getAbsolutePath());
 				}
 			});
 			resourcePackField.set(FMLClientHandler.instance(), packs);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ASMHelper.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ASMHelper.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v18.asm.lib;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.launchwrapper.LaunchClassLoader;
+import nova.internal.core.Game;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
@@ -134,7 +135,7 @@ public class ASMHelper {
 				if (method == null) {
 					throw new RuntimeException("Method not found: " + injector.method);
 				}
-				System.out.println("Injecting into " + injector.method + "\n" + printInsnList(injector.injection));
+				Game.logger().info("Injecting into {}\n{}", injector.method, printInsnList(injector.injection));
 
 				List<AbstractInsnNode> callNodes;
 				if (injector.before) {
@@ -149,10 +150,10 @@ public class ASMHelper {
 
 				for (AbstractInsnNode node : callNodes) {
 					if (injector.before) {
-						System.out.println("Injected before: " + printInsn(node));
+						Game.logger().info("Injected before: {}", printInsn(node));
 						method.instructions.insertBefore(node, cloneInsnList(injector.injection));
 					} else {
-						System.out.println("Injected after: " + printInsn(node));
+						Game.logger().info("Injected after: {}", printInsn(node));
 						method.instructions.insert(node, cloneInsnList(injector.injection));
 					}
 				}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ComponentInjector.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ComponentInjector.java
@@ -26,6 +26,7 @@ import nova.core.component.ComponentProvider;
 import nova.core.component.Passthrough;
 import nova.core.network.NetworkTarget.Side;
 import nova.core.util.ClassLoaderUtil;
+import nova.internal.core.Game;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -70,7 +71,7 @@ public class ComponentInjector<T> implements Opcodes {
 
 			if (components.size() > 0) {
 				List<Class<? extends Component>> componentClazzes = components.stream().map(c -> c.getClass()).collect(Collectors.toList());
-				System.out.println(Side.get() + " " + componentClazzes);
+				Game.logger().info("{} {}", Side.get(), componentClazzes);
 				if (cache.containsKey(componentClazzes))
 				// Cached class
 				{

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/ChunkTransformer.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/ChunkTransformer.java
@@ -22,6 +22,7 @@ package nova.core.wrapper.mc.forge.v18.asm.transformers;
 
 import nova.core.wrapper.mc.forge.v18.asm.lib.ASMHelper;
 import nova.core.wrapper.mc.forge.v18.asm.lib.ObfMapping;
+import nova.internal.core.Game;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
@@ -35,12 +36,24 @@ public class ChunkTransformer implements Transformer {
 
 	@Override
 	public void transform(ClassNode cnode) {
-		System.out.println("[NOVA] Transforming Chunk class for chunkModified event.");
+		Game.logger().info("Transforming Chunk class for chunkModified event.");
 
 		//obf name: func_177436_a
-		MethodNode method = ASMHelper.findMethod(new ObfMapping("net/minecraft/world/chunk/Chunk", "setBlockState", "(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/block/state/IBlockState;"), cnode);
+		ObfMapping obfMap = new ObfMapping("bfh", "a", "(Ldt;Lbec;)Lbec;");
+		ObfMapping deobfMap = new ObfMapping("net/minecraft/world/chunk/Chunk", "setBlockState", "(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/block/state/IBlockState;");
 
-		System.out.println("[NOVA] Found method " + method.name);
+		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
+
+		if (method == null) {
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
+			method = ASMHelper.findMethod(deobfMap, cnode);
+
+			if (method == null) {
+				throw new IllegalStateException("[NOVA] Lookup " + deobfMap + " failed!");
+			}
+		}
+
+		Game.logger().info("Found method {}", method.name);
 
 		InsnList list = new InsnList();
 		list.add(new VarInsnNode(ALOAD, 0)); //this
@@ -60,6 +73,6 @@ public class ChunkTransformer implements Transformer {
 			method.instructions.insert(list);
 		}
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/GameDataTransformer.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/GameDataTransformer.java
@@ -21,6 +21,7 @@ package nova.core.wrapper.mc.forge.v18.asm.transformers;
 
 import nova.core.wrapper.mc.forge.v18.asm.lib.ASMHelper;
 import nova.core.wrapper.mc.forge.v18.asm.lib.ObfMapping;
+import nova.internal.core.Game;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.JumpInsnNode;
@@ -35,7 +36,7 @@ public class GameDataTransformer implements Transformer {
 
 	@Override
 	public void transform(ClassNode cnode) {
-		System.out.println("[NOVA] Transforming GameData class for correct NOVA mod id mapping.");
+		Game.logger().info("Transforming GameData class for correct NOVA mod id mapping.");
 		transformAddPrefix(cnode);
 		transformRegisterBlock(cnode);
 		transformRegisterItem(cnode);
@@ -49,7 +50,7 @@ public class GameDataTransformer implements Transformer {
 			throw new IllegalStateException("[NOVA] Lookup " + mapping + " failed!");
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		@SuppressWarnings("unchecked")
 		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(49);
@@ -61,7 +62,7 @@ public class GameDataTransformer implements Transformer {
 
 		method.instructions.insert(prev, list);
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 
 	private void transformRegisterBlock(ClassNode cnode) {
@@ -71,7 +72,7 @@ public class GameDataTransformer implements Transformer {
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
 			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
@@ -79,7 +80,7 @@ public class GameDataTransformer implements Transformer {
 			}
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		@SuppressWarnings("unchecked")
 		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(12);
@@ -91,7 +92,7 @@ public class GameDataTransformer implements Transformer {
 
 		method.instructions.insert(prev, list);
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 
 	private void transformRegisterItem(ClassNode cnode) {
@@ -101,7 +102,7 @@ public class GameDataTransformer implements Transformer {
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
 			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
@@ -109,7 +110,7 @@ public class GameDataTransformer implements Transformer {
 			}
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		@SuppressWarnings("unchecked")
 		JumpInsnNode prev = (JumpInsnNode) method.instructions.get(12);
@@ -121,6 +122,6 @@ public class GameDataTransformer implements Transformer {
 
 		method.instructions.insert(prev, list);
 
-		System.out.println("[NOVA] Injected instruction to method: " + method.name);
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/TileEntityTransformer.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/transformers/TileEntityTransformer.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v18.asm.transformers;
 import nova.core.wrapper.mc.forge.v18.asm.lib.ASMHelper;
 import nova.core.wrapper.mc.forge.v18.asm.lib.InstructionComparator;
 import nova.core.wrapper.mc.forge.v18.asm.lib.ObfMapping;
+import nova.internal.core.Game;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.MethodInsnNode;
@@ -34,7 +35,7 @@ public class TileEntityTransformer implements Transformer {
 	@Override
 	public void transform(ClassNode cnode) {
 
-		System.out.println("[NOVA] Transforming TileEntity class for dynamic instance injection.");
+		Game.logger().info("Transforming TileEntity class for dynamic instance injection.");
 
 		ObfMapping obfMap = new ObfMapping("bcm", "c", "(Lfn;)Lbcm;");
 		ObfMapping deobfMap = new ObfMapping("net/minecraft/tileentity/TileEntity", "createAndLoadEntity", "(Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/tileentity/TileEntity;");
@@ -42,15 +43,15 @@ public class TileEntityTransformer implements Transformer {
 		MethodNode method = ASMHelper.findMethod(obfMap, cnode);
 
 		if (method == null) {
-			System.out.println("[NOVA] Lookup " + obfMap + " failed. You are probably in a deobf environment.");
+			Game.logger().warn("Lookup {} failed. You are probably in a deobf environment.", obfMap);
 			method = ASMHelper.findMethod(deobfMap, cnode);
 
 			if (method == null) {
-				System.out.println("[NOVA] Lookup " + deobfMap + " failed!");
+				throw new IllegalStateException("[NOVA] Lookup " + deobfMap + " failed!");
 			}
 		}
 
-		System.out.println("[NOVA] Transforming method " + method.name);
+		Game.logger().info("Transforming method {}", method.name);
 
 		ASMHelper.removeBlock(method.instructions, new InstructionComparator.InsnListSection(method.instructions, 23, 26));
 
@@ -61,5 +62,7 @@ public class TileEntityTransformer implements Transformer {
 		list.add(new VarInsnNode(ASTORE, 1));
 
 		method.instructions.insert(method.instructions.get(22), list);
+
+		Game.logger().info("Injected instruction to method: {}", method.name);
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/NovaMinecraft.java
@@ -209,7 +209,7 @@ public class NovaMinecraft {
 			FMLCommonHandler.instance().bus().register(new FMLEventHandler());
 			MinecraftForge.EVENT_BUS.register(Game.retention());
 		} catch (Exception e) {
-			System.out.println("Error during preInit");
+			Game.logger().error("Error during preInit", e);
 			e.printStackTrace();
 			throw new InitializationException(e);
 		}
@@ -233,7 +233,7 @@ public class NovaMinecraft {
 			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
-			System.out.println("Error during init");
+			Game.logger().error("Error during init", e);
 			e.printStackTrace();
 			throw new InitializationException(e);
 		}
@@ -258,7 +258,7 @@ public class NovaMinecraft {
 			fmlProgressBar.finish();
 			ProgressManager.pop(progressBar);
 		} catch (Exception e) {
-			System.out.println("Error during postInit");
+			Game.logger().error("Error during postInit", e);
 			e.printStackTrace();
 			throw new InitializationException(e);
 		}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/manager/MCRetentionManager.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/manager/MCRetentionManager.java
@@ -87,7 +87,7 @@ public class MCRetentionManager extends RetentionManager {
 			tempFile.renameTo(file);
 			return true;
 		} catch (Exception e) {
-			System.out.println("Failed to queueSave " + file.getName() + ".dat!");
+			Game.logger().error("Failed to queueSave {}!", file.getName(), e);
 			e.printStackTrace();
 			return false;
 		}
@@ -109,7 +109,7 @@ public class MCRetentionManager extends RetentionManager {
 				return new NBTTagCompound();
 			}
 		} catch (Exception e) {
-			System.out.println("Failed to load " + file.getName() + ".dat!");
+			Game.logger().error("Failed to load {}!", file.getName(), e);
 			e.printStackTrace();
 			return null;
 		}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/ReflectionUtil.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/ReflectionUtil.java
@@ -40,6 +40,7 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
+import nova.internal.core.Game;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -147,7 +148,7 @@ public class ReflectionUtil {
 		try {
 			return (List<ArrayList<ItemStack>>) OREDICTIONARY_IDTOSTACK.get(null);
 		} catch (IllegalAccessException ex) {
-			logError("ERROR - could not load ore dictionary stacks!");
+			Game.logger().error("ERROR - could not load ore dictionary stacks!");
 			return null;
 		}
 	}
@@ -156,7 +157,7 @@ public class ReflectionUtil {
 		try {
 			return (List<ArrayList<ItemStack>>) OREDICTIONARY_IDTOSTACKUN.get(null);
 		} catch (IllegalAccessException ex) {
-			logError("ERROR - could not load ore dictionary stacks!");
+			Game.logger().error("ERROR - could not load ore dictionary stacks!");
 			return null;
 		}
 	}
@@ -165,7 +166,7 @@ public class ReflectionUtil {
 		try {
 			return (File) MINECRAFTSERVER_ANVILFILE.get(server);
 		} catch (IllegalAccessException ex) {
-			logError("could not load anvil file!");
+			Game.logger().error("could not load anvil file!");
 			return null;
 		}
 	}
@@ -187,7 +188,7 @@ public class ReflectionUtil {
 		try {
 			return SHAPEDORERECIPE_WIDTH.getInt(recipe);
 		} catch (IllegalAccessException ex) {
-			logError("could not load shaped ore recipe width!");
+			Game.logger().error("could not load shaped ore recipe width!");
 			return 3;
 		}
 	}
@@ -196,7 +197,7 @@ public class ReflectionUtil {
 		try {
 			return (Container) INVENTORYCRAFTING_EVENTHANDLER.get(inventory);
 		} catch (IllegalAccessException ex) {
-			logError("could not get inventory eventhandler");
+			Game.logger().error("could not get inventory eventhandler");
 			return null;
 		}
 	}
@@ -205,7 +206,7 @@ public class ReflectionUtil {
 		try {
 			return (EntityPlayer) SLOTCRAFTING_PLAYER.get(slot);
 		} catch (IllegalAccessException ex) {
-			logError("could not get inventory eventhandler");
+			Game.logger().error("could not get inventory eventhandler");
 			return null;
 		}
 	}
@@ -215,7 +216,7 @@ public class ReflectionUtil {
 			Field field = getField(StringTranslate.class, ObfuscationConstants.STRINGTRANSLATE_INSTANCE);
 			return (StringTranslate) field.get(null);
 		} catch (IllegalAccessException ex) {
-			logError("could not get string translator");
+			Game.logger().error("could not get string translator");
 			return null;
 		}
 	}
@@ -224,7 +225,7 @@ public class ReflectionUtil {
 		try {
 			return (ItemStack) SEEDENTRY_SEED.get(entry);
 		} catch (IllegalAccessException ex) {
-			logError("could not get SeedEntry seed");
+			Game.logger().error("could not get SeedEntry seed");
 			return null;
 		}
 	}
@@ -234,7 +235,7 @@ public class ReflectionUtil {
 			CraftingManager.getInstance(),
 			craftingRecipeList,
 			ObfuscationConstants.CRAFTINGMANAGER_RECIPES)) {
-			logError("could not set crafting recipe list");
+			Game.logger().error("could not set crafting recipe list");
 		}
 	}
 
@@ -242,15 +243,15 @@ public class ReflectionUtil {
 		try {
 			return SEEDENTRY_CONSTRUCTOR.newInstance(MineTweakerMC.getItemStack(stack.getStack()), (int) stack.getChance());
 		} catch (InstantiationException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		} catch (IllegalAccessException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		} catch (IllegalArgumentException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		} catch (InvocationTargetException ex) {
-			logError("could not construct SeedEntry");
+			Game.logger().error("could not construct SeedEntry");
 		}
-		
+
 		return null;
 	}*/
 
@@ -319,9 +320,5 @@ public class ReflectionUtil {
 		}
 
 		return null;
-	}
-
-	private static void logError(String message) {
-		System.out.println("ERROR: " + message);
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
@@ -148,6 +148,6 @@ public class BlockConverter implements NativeConverter<Block, net.minecraft.bloc
 			blockWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, blockWrapper));
 		}
 
-		System.out.println("[NOVA]: Registered '" + blockFactory.getID() + "' block.");
+		Game.logger().info("Registered block: {}", blockFactory.getID());
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
@@ -220,7 +220,7 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 				itemWrapper.setCreativeTab(CategoryConverter.instance().toNative(category, itemWrapper));
 			}
 
-			System.out.println("[NOVA]: Registered '" + itemFactory.getID() + "' item.");
+			Game.logger().info("Registered item: {}", itemFactory.getID());
 		}
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/recipes/MinecraftRecipeRegistry.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/recipes/MinecraftRecipeRegistry.java
@@ -78,7 +78,7 @@ public class MinecraftRecipeRegistry {
 
 		ReflectionUtil.setCraftingRecipeList(new RecipeListWrapper(recipes));
 
-		System.out.println("Initialized recipes in " + (System.currentTimeMillis() - startTime) + " ms");
+		Game.logger().info("Initialized recipes in {} ms", (System.currentTimeMillis() - startTime));
 
 		recipeManager.whenRecipeAdded(CraftingRecipe.class, this::onNOVARecipeAdded);
 		recipeManager.whenRecipeRemoved(CraftingRecipe.class, this::onNOVARecipeRemoved);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/recipes/backward/MCCraftingGrid.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/recipes/backward/MCCraftingGrid.java
@@ -132,7 +132,7 @@ public class MCCraftingGrid implements CraftingGrid {
 
 		for (int i = 0; i < inventory.getSizeInventory(); i++) {
 			if (changed(i)) {
-				//System.out.println("Slot " + i + " changed");
+				//Game.logger().info("Slot {} changed", i);
 				original[i] = inventory.getStackInSlot(i);
 				if (inventory.getStackInSlot(i) != null) {
 					if (items[i] == null) {
@@ -149,7 +149,7 @@ public class MCCraftingGrid implements CraftingGrid {
 				}
 			}
 		}
-		//System.out.println("Num stack count: " + itemCount);
+		//Game.logger().info("Num stack count: {}", itemCount);
 	}
 
 	@Override
@@ -189,7 +189,7 @@ public class MCCraftingGrid implements CraftingGrid {
 
 	@Override
 	public boolean setCrafting(int x, int y, Optional<nova.core.item.Item> item) {
-		//System.out.println("SetStack(" + x + ", " + y + ") " + stack);
+		//Game.logger().info("setCrafting({}, {}) {}", x, y, item);
 
 		int ix = y * width + x;
 		if (item.isPresent()) {
@@ -213,7 +213,7 @@ public class MCCraftingGrid implements CraftingGrid {
 
 	@Override
 	public boolean setCrafting(int i, Optional<nova.core.item.Item> item) {
-		//System.out.println("SetStack(" + i + ") " + stack);
+		//Game.logger().info("setCrafting({}) {}", i, item);
 
 		if (item.isPresent()) {
 			if (items[i] == null) {

--- a/src/main/java/nova/internal/core/Game.java
+++ b/src/main/java/nova/internal/core/Game.java
@@ -39,9 +39,13 @@ import nova.core.language.LanguageManager;
 import nova.core.util.registry.RetentionManager;
 import nova.core.world.WorldManager;
 import nova.internal.core.bootstrap.DependencyInjectionEntryPoint;
+import nova.internal.core.di.LoggerModule;
 import nova.internal.core.tick.UpdateTicker;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.jbee.inject.Injector;
+
+import java.util.Optional;
 
 public class Game {
 
@@ -147,7 +151,7 @@ public class Game {
 	}
 
 	public static Logger logger() {
-		return instance.logger;
+		return Optional.ofNullable(instance).map(instance -> instance.logger).orElseGet(() -> LoggerFactory.getLogger(LoggerModule.getDefaultName()));
 	}
 
 	public static ClientManager clientManager() {

--- a/src/main/java/nova/internal/core/di/LoggerModule.java
+++ b/src/main/java/nova/internal/core/di/LoggerModule.java
@@ -67,7 +67,7 @@ public class LoggerModule extends BinderModule {
 		@Override
 		public Logger supply(Dependency<? super Logger> dependency, Injector injector) {
 			if (dependency.isUntargeted() || isForGame(dependency)) {
-				return LoggerFactory.getLogger("General");
+				return LoggerFactory.getLogger("NOVA");
 			} else {
 				return StreamSupport.stream(dependency.spliterator(), false)
 					.map(target -> target.getTarget().getInstance().getType().getRawType())

--- a/src/main/java/nova/internal/core/di/LoggerModule.java
+++ b/src/main/java/nova/internal/core/di/LoggerModule.java
@@ -31,6 +31,7 @@ import se.jbee.inject.Supplier;
 import se.jbee.inject.bind.BinderModule;
 import se.jbee.inject.util.Scoped;
 
+import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 /**
@@ -38,8 +39,35 @@ import java.util.stream.StreamSupport;
  */
 public class LoggerModule extends BinderModule {
 
+	private static boolean defaultNameChangeable = true;
+	private static Optional<String> defaultName = Optional.empty();
+
+	/**
+	 * Changes the default logger name (the name of the logger injected into Game),
+	 * must be called before doing any dependency injection.
+	 * <p>
+	 * Is really only useful for engine implementations using NOVA.
+	 *
+	 * @param name The new name.
+	 */
+	public static void setDefaultName(String name) {
+		if (defaultNameChangeable) {
+			defaultName = Optional.of(name);
+		}
+	}
+
+	/**
+	 * Gets the default logger name (the name of the logger injected into Game)
+	 *
+	 * @return The default logger name (or {@code "NOVA"} if no default logger name was set)
+	 */
+	public static String getDefaultName() {
+		return defaultName.orElse("NOVA");
+	}
+
 	public LoggerModule() {
 		super(Scoped.DEPENDENCY);
+		defaultNameChangeable = false;
 	}
 
 	@Override
@@ -67,7 +95,7 @@ public class LoggerModule extends BinderModule {
 		@Override
 		public Logger supply(Dependency<? super Logger> dependency, Injector injector) {
 			if (dependency.isUntargeted() || isForGame(dependency)) {
-				return LoggerFactory.getLogger("NOVA");
+				return LoggerFactory.getLogger(getDefaultName());
 			} else {
 				return StreamSupport.stream(dependency.spliterator(), false)
 					.map(target -> target.getTarget().getInstance().getType().getRawType())

--- a/src/test/java/nova/internal/core/di/LoggerModuleTest.java
+++ b/src/test/java/nova/internal/core/di/LoggerModuleTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017 NOVA, All rights reserved.
+ * This library is free software, licensed under GNU Lesser General Public License version 3
+ *
+ * This file is part of NOVA.
+ *
+ * NOVA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * NOVA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nova.internal.core.di;
+
+import nova.internal.core.Game;
+import nova.wrappertests.NovaLauncherTestFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author ExE Boss
+ */
+public class LoggerModuleTest {
+
+	@Before
+	public void setup() throws NoSuchFieldException, IllegalAccessException {
+		Field field = LoggerModule.class.getDeclaredField("defaultNameChangeable");
+		field.setAccessible(true);
+		field.set(null, true);
+		field.setAccessible(false);
+	}
+
+	@Test
+	public void testCustomLoggerName() {
+		assertThat(LoggerModule.getDefaultName()).isEqualTo("NOVA");
+		LoggerModule.setDefaultName("Unset");
+		assertThat(LoggerModule.getDefaultName()).isEqualTo("Unset");
+		LoggerModule.setDefaultName("Custom");
+		NovaLauncherTestFactory.createDummyLauncher();
+		assertThat(Game.logger().getName()).isEqualTo("Custom");
+		assertThat(LoggerModule.getDefaultName()).isEqualTo("Custom").isEqualTo(Game.logger().getName());
+	}
+}

--- a/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
+++ b/src/test/java/nova/internal/core/launch/NovaLauncherTest.java
@@ -22,6 +22,7 @@ package nova.internal.core.launch;
 
 import nova.internal.core.Game;
 import nova.internal.core.bootstrap.DependencyInjectionEntryPoint;
+import nova.internal.core.di.LoggerModule;
 import nova.testutils.mod.TestMod;
 import nova.testutils.mod.TestModDuplicate;
 import nova.testutils.mod.TestModWithLogger;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static nova.testutils.NovaAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class NovaLauncherTest extends AbstractNovaLauncherTest {
 


### PR DESCRIPTION
This PR makes it so that slf4j logging messages actually show up in the Minecraft logs.

### Complete:
- [x] Replace all instances of `System.out.println(...)` with `Game.logger().info(...)` and `System.err.println(...)` with `Game.logger().warn/error(...)`