### PR TITLE
Change the Block coordinate methods (x(), y(), z()) return type to long

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
@@ -70,7 +70,7 @@ public class BWBlock extends Block implements Storable {
 		this.mcBlock = block;
 		components.add(new BWBlockTransform(this, world, pos));
 		components.add(new BlockProperty.Opacity().setOpacity(mcBlock.getMaterial().isOpaque() ? 1 : 0));
-		if (mcBlock.isReplaceable(getMcBlockAccess(), xi(), yi(), zi()))
+		if (mcBlock.isReplaceable(blockAccess(), xi(), yi(), zi()))
 			components.add(BlockProperty.Replaceable.instance());
 
 		BlockProperty.BlockSound blockSound = components.add(new BlockProperty.BlockSound());
@@ -78,14 +78,14 @@ public class BWBlock extends Block implements Storable {
 		blockSound.setBlockSound(BlockProperty.BlockSound.BlockSoundTrigger.BREAK, new Sound("", mcBlock.stepSound.getBreakSound()));
 		blockSound.setBlockSound(BlockProperty.BlockSound.BlockSoundTrigger.WALK, new Sound("", mcBlock.stepSound.getStepResourcePath()));
 
-		components.add(new LightEmitter()).setEmittedLevel(() -> mcBlock.getLightValue(getMcBlockAccess(), xi(), yi(), zi()) / 15.0);
+		components.add(new LightEmitter()).setEmittedLevel(() -> mcBlock.getLightValue(blockAccess(), xi(), yi(), zi()) / 15.0);
 		components.add(new Collider(this))
 			.setBoundingBox(() -> new Cuboid(mcBlock.getBlockBoundsMinX(), mcBlock.getBlockBoundsMinY(), mcBlock.getBlockBoundsMinZ(), mcBlock.getBlockBoundsMaxX(), mcBlock.getBlockBoundsMaxY(), mcBlock.getBlockBoundsMaxZ()))
 			.setOcclusionBoxes(entity -> {
 				List<AxisAlignedBB> aabbs = new ArrayList<>();
-				if (getMcBlockAccess() instanceof net.minecraft.world.World)
+				if (blockAccess() instanceof net.minecraft.world.World)
 					mcBlock.addCollisionBoxesToList(
-						(net.minecraft.world.World) getMcBlockAccess(),
+						(net.minecraft.world.World) blockAccess(),
 						(int) position().getX(),
 						(int) position().getY(),
 						(int) position().getZ(),
@@ -101,7 +101,7 @@ public class BWBlock extends Block implements Storable {
 					.map(cuboid -> cuboid.subtract(pos))
 					.collect(Collectors.toSet());
 			}).setSelectionBoxes(entity -> {
-				final AxisAlignedBB bb = mcBlock.getSelectedBoundingBoxFromPool(((net.minecraft.world.World) getMcBlockAccess()), xi(), yi(), zi());
+				final AxisAlignedBB bb = mcBlock.getSelectedBoundingBoxFromPool(((net.minecraft.world.World) blockAccess()), xi(), yi(), zi());
 				Cuboid cuboid = CuboidConverter.instance().toNova(bb);
 				return Collections.singleton(cuboid.subtract(position()));
 			});
@@ -128,33 +128,33 @@ public class BWBlock extends Block implements Storable {
 		return (int) z();
 	}
 
-	public IBlockAccess getMcBlockAccess() {
+	public IBlockAccess blockAccess() {
 		return WorldConverter.instance().toNative(world());
 	}
 
 	public int getMetadata() {
-		return getMcBlockAccess().getBlockMetadata(xi(), yi(), zi());
+		return blockAccess().getBlockMetadata(xi(), yi(), zi());
 	}
 
 	public Optional<TileEntity> getTileEntity() {
 		if (mcTileEntity == null && mcBlock.hasTileEntity(getMetadata())) {
-			mcTileEntity = getMcBlockAccess().getTileEntity(xi(), yi(), zi());
+			mcTileEntity = blockAccess().getTileEntity(xi(), yi(), zi());
 		}
 		return  Optional.ofNullable(mcTileEntity);
 	}
 
 	@Override
 	public boolean canReplace() {
-		return mcBlock.canPlaceBlockAt((net.minecraft.world.World) getMcBlockAccess(), xi(), yi(), zi());
+		return mcBlock.canPlaceBlockAt((net.minecraft.world.World) blockAccess(), xi(), yi(), zi());
 	}
 
 	@Override
 	public boolean shouldDisplacePlacement() {
-		if (mcBlock == Blocks.snow_layer && (getMcBlockAccess().getBlockMetadata(xi(), yi(), zi()) & 7) < 1) {
+		if (mcBlock == Blocks.snow_layer && (blockAccess().getBlockMetadata(xi(), yi(), zi()) & 7) < 1) {
 			return false;
 		}
 
-		if (mcBlock == Blocks.vine || mcBlock == Blocks.tallgrass || mcBlock == Blocks.deadbush || mcBlock.isReplaceable(getMcBlockAccess(), xi(), yi(), zi())) {
+		if (mcBlock == Blocks.vine || mcBlock == Blocks.tallgrass || mcBlock == Blocks.deadbush || mcBlock.isReplaceable(blockAccess(), xi(), yi(), zi())) {
 			return false;
 		}
 		return super.shouldDisplacePlacement();

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
@@ -43,12 +43,15 @@ import nova.core.sound.Sound;
 import nova.core.util.shape.Cuboid;
 import nova.core.world.World;
 import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
-import nova.core.wrapper.mc.forge.v17.wrapper.block.world.BWWorld;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.cuboid.CuboidConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -67,7 +70,7 @@ public class BWBlock extends Block implements Storable {
 		this.mcBlock = block;
 		components.add(new BWBlockTransform(this, world, pos));
 		components.add(new BlockProperty.Opacity().setOpacity(mcBlock.getMaterial().isOpaque() ? 1 : 0));
-		if (mcBlock.isReplaceable(getMcBlockAccess(), x(), y(), z()))
+		if (mcBlock.isReplaceable(getMcBlockAccess(), xi(), yi(), zi()))
 			components.add(BlockProperty.Replaceable.instance());
 
 		BlockProperty.BlockSound blockSound = components.add(new BlockProperty.BlockSound());
@@ -75,29 +78,35 @@ public class BWBlock extends Block implements Storable {
 		blockSound.setBlockSound(BlockProperty.BlockSound.BlockSoundTrigger.BREAK, new Sound("", mcBlock.stepSound.getBreakSound()));
 		blockSound.setBlockSound(BlockProperty.BlockSound.BlockSoundTrigger.WALK, new Sound("", mcBlock.stepSound.getStepResourcePath()));
 
-		components.add(new LightEmitter()).setEmittedLevel(() -> mcBlock.getLightValue(getMcBlockAccess(), x(), y(), z()) / 15.0);
+		components.add(new LightEmitter()).setEmittedLevel(() -> mcBlock.getLightValue(getMcBlockAccess(), xi(), yi(), zi()) / 15.0);
 		components.add(new Collider(this))
 			.setBoundingBox(() -> new Cuboid(mcBlock.getBlockBoundsMinX(), mcBlock.getBlockBoundsMinY(), mcBlock.getBlockBoundsMinZ(), mcBlock.getBlockBoundsMaxX(), mcBlock.getBlockBoundsMaxY(), mcBlock.getBlockBoundsMaxZ()))
 			.setOcclusionBoxes(entity -> {
 				List<AxisAlignedBB> aabbs = new ArrayList<>();
-				mcBlock.addCollisionBoxesToList(
-					Game.natives().toNative(world()),
-					(int) position().getX(),
-					(int) position().getY(),
-					(int) position().getZ(),
-					Game.natives().toNative(entity.isPresent() ? entity.get().components.get(Collider.class).boundingBox.get() : Cuboid.ONE.add(pos)),
-					aabbs,
-					entity.isPresent() ? Game.natives().toNative(entity.get()) : null
-				);
-
+				if (getMcBlockAccess() instanceof net.minecraft.world.World)
+					mcBlock.addCollisionBoxesToList(
+						(net.minecraft.world.World) getMcBlockAccess(),
+						(int) position().getX(),
+						(int) position().getY(),
+						(int) position().getZ(),
+						CuboidConverter.instance().toNative(entity
+							.flatMap(e -> e.components.getOp(Collider.class))
+							.map(c -> c.boundingBox.get())
+							.orElseGet(() -> Cuboid.ONE.add(pos))),
+						aabbs,
+						entity.map(EntityConverter.instance()::toNative).orElse(null)
+					);
 				return aabbs.stream()
-					.map(aabb -> (Cuboid) Game.natives().toNova(aabb))
+					.map(CuboidConverter.instance()::toNova)
 					.map(cuboid -> cuboid.subtract(pos))
 					.collect(Collectors.toSet());
+			}).setSelectionBoxes(entity -> {
+				final AxisAlignedBB bb = mcBlock.getSelectedBoundingBoxFromPool(((net.minecraft.world.World) getMcBlockAccess()), xi(), yi(), zi());
+				Cuboid cuboid = CuboidConverter.instance().toNova(bb);
+				return Collections.singleton(cuboid.subtract(position()));
 			});
-		//TODO: Set selection bounds
 		components.add(new StaticRenderer())
-			.onRender(model -> model.addChild(new CustomModel(self -> RenderBlocks.getInstance().renderStandardBlock(mcBlock, x(), y(), z()))));
+			.onRender(model -> model.addChild(new CustomModel(self -> RenderBlocks.getInstance().renderStandardBlock(mcBlock, xi(), yi(), zi()))));
 		WrapperEvent.BWBlockCreate event = new WrapperEvent.BWBlockCreate(world, pos, this, mcBlock);
 		Game.events().publish(event);
 	}
@@ -107,37 +116,45 @@ public class BWBlock extends Block implements Storable {
 		return Game.natives().toNova(new ItemStack(Item.getItemFromBlock(mcBlock)));
 	}
 
+	public int xi() {
+		return (int) x();
+	}
+
+	public int yi() {
+		return (int) y();
+	}
+
+	public int zi() {
+		return (int) z();
+	}
+
 	public IBlockAccess getMcBlockAccess() {
 		return WorldConverter.instance().toNative(world());
 	}
 
 	public int getMetadata() {
-		return getMcBlockAccess().getBlockMetadata(x(), y(), z());
+		return getMcBlockAccess().getBlockMetadata(xi(), yi(), zi());
 	}
 
 	public Optional<TileEntity> getTileEntity() {
-		return Optional.ofNullable(getTileEntityImpl());
-	}
-
-	private TileEntity getTileEntityImpl() {
 		if (mcTileEntity == null && mcBlock.hasTileEntity(getMetadata())) {
-			mcTileEntity = getMcBlockAccess().getTileEntity(x(), y(), z());
+			mcTileEntity = getMcBlockAccess().getTileEntity(xi(), yi(), zi());
 		}
-		return mcTileEntity;
+		return  Optional.ofNullable(mcTileEntity);
 	}
 
 	@Override
 	public boolean canReplace() {
-		return mcBlock.canPlaceBlockAt((net.minecraft.world.World) getMcBlockAccess(), x(), y(), z());
+		return mcBlock.canPlaceBlockAt((net.minecraft.world.World) getMcBlockAccess(), xi(), yi(), zi());
 	}
 
 	@Override
 	public boolean shouldDisplacePlacement() {
-		if (mcBlock == Blocks.snow_layer && (getMcBlockAccess().getBlockMetadata(x(), y(), z()) & 7) < 1) {
+		if (mcBlock == Blocks.snow_layer && (getMcBlockAccess().getBlockMetadata(xi(), yi(), zi()) & 7) < 1) {
 			return false;
 		}
 
-		if (mcBlock == Blocks.vine || mcBlock == Blocks.tallgrass || mcBlock == Blocks.deadbush || mcBlock.isReplaceable(getMcBlockAccess(), x(), y(), z())) {
+		if (mcBlock == Blocks.vine || mcBlock == Blocks.tallgrass || mcBlock == Blocks.deadbush || mcBlock.isReplaceable(getMcBlockAccess(), xi(), yi(), zi())) {
 			return false;
 		}
 		return super.shouldDisplacePlacement();
@@ -146,23 +163,17 @@ public class BWBlock extends Block implements Storable {
 	@Override
 	public void save(Data data) {
 		Storable.super.save(data);
-
-		TileEntity tileEntity = getTileEntityImpl();
-		if (tileEntity != null) {
+		getTileEntity().ifPresent(tile -> {
 			NBTTagCompound nbt = new NBTTagCompound();
-			tileEntity.writeToNBT(nbt);
-			data.putAll(Game.natives().toNova(nbt));
-		}
+			tile.writeToNBT(nbt);
+			data.putAll(DataConverter.instance().toNova(nbt));
+		});
 	}
 
 	@Override
 	public void load(Data data) {
 		Storable.super.load(data);
-
-		TileEntity tileEntity = getTileEntityImpl();
-		if (tileEntity != null) {
-			tileEntity.writeToNBT(Game.natives().toNative(data));
-		}
+		getTileEntity().ifPresent(tile -> tile.readFromNBT(DataConverter.instance().toNative(data)));
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
@@ -128,6 +128,10 @@ public class BWBlock extends Block implements Storable {
 		return (int) z();
 	}
 
+	public net.minecraft.block.Block block() {
+		return mcBlock;
+	}
+
 	public IBlockAccess blockAccess() {
 		return WorldConverter.instance().toNative(world());
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
@@ -45,12 +45,17 @@ import nova.core.sound.Sound;
 import nova.core.util.shape.Cuboid;
 import nova.core.world.World;
 import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
+import nova.core.wrapper.mc.forge.v18.wrapper.VectorConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.world.WorldConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.cuboid.CuboidConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.data.DataConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.backward.BWBakedModel;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -82,21 +87,27 @@ public class BWBlock extends Block implements Storable {
 			.setBoundingBox(() -> new Cuboid(mcBlock.getBlockBoundsMinX(), mcBlock.getBlockBoundsMinY(), mcBlock.getBlockBoundsMinZ(), mcBlock.getBlockBoundsMaxX(), mcBlock.getBlockBoundsMaxY(), mcBlock.getBlockBoundsMaxZ()))
 			.setOcclusionBoxes(entity -> {
 				List<AxisAlignedBB> aabbs = new ArrayList<>();
-				mcBlock.addCollisionBoxesToList(
-					Game.natives().toNative(world()),
-					new BlockPos(x(), y(), z()),
-					blockState(),
-					Game.natives().toNative(entity.isPresent() ? entity.get().components.get(Collider.class).boundingBox.get() : Cuboid.ONE.add(pos)),
-					aabbs,
-					entity.isPresent() ? Game.natives().toNative(entity.get()) : null
-				);
-
+				if (getMcBlockAccess() instanceof net.minecraft.world.World)
+					mcBlock.addCollisionBoxesToList(
+						(net.minecraft.world.World) getMcBlockAccess(),
+						blockPos(),
+						blockState(),
+						CuboidConverter.instance().toNative(entity
+							.flatMap(e -> e.components.getOp(Collider.class))
+							.map(c -> c.boundingBox.get())
+							.orElseGet(() -> Cuboid.ONE.add(pos))),
+						aabbs,
+						entity.map(EntityConverter.instance()::toNative).orElse(null)
+					);
 				return aabbs.stream()
-					.map(aabb -> (Cuboid) Game.natives().toNova(aabb))
+					.map(CuboidConverter.instance()::toNova)
 					.map(cuboid -> cuboid.subtract(pos))
 					.collect(Collectors.toSet());
+			}).setSelectionBoxes(entity -> {
+				final AxisAlignedBB bb = mcBlock.getSelectedBoundingBox(((net.minecraft.world.World) getMcBlockAccess()), blockPos());
+				Cuboid cuboid = CuboidConverter.instance().toNova(bb);
+				return Collections.singleton(cuboid.subtract(position()));
 			});
-		//TODO: Set selection bounds
 		components.add(new StaticRenderer())
 			.onRender(model -> {
 				switch (block.getRenderType()) {
@@ -114,7 +125,7 @@ public class BWBlock extends Block implements Storable {
 					case 3:
 						// model rendering
 						model.addChild(new BWBakedModel(Minecraft.getMinecraft().getBlockRendererDispatcher()
-							.getModelFromBlockState(blockState(), getMcBlockAccess(), new BlockPos(x(), y(), z())), DefaultVertexFormats.BLOCK));
+							.getModelFromBlockState(blockState(), getMcBlockAccess(), blockPos()), DefaultVertexFormats.BLOCK));
 						break;
 				}
 			});
@@ -129,6 +140,10 @@ public class BWBlock extends Block implements Storable {
 		return Game.natives().toNova(new ItemStack(Item.getItemFromBlock(mcBlock)));
 	}
 
+	public BlockPos blockPos() {
+		return VectorConverter.instance().toNative(position());
+	}
+
 	public IBlockAccess getMcBlockAccess() {
 		return WorldConverter.instance().toNative(world());
 	}
@@ -138,14 +153,10 @@ public class BWBlock extends Block implements Storable {
 	}
 
 	public Optional<TileEntity> getTileEntity() {
-		return Optional.ofNullable(getTileEntityImpl());
-	}
-
-	private TileEntity getTileEntityImpl() {
 		if (mcTileEntity == null && mcBlock.hasTileEntity(blockState())) {
-			mcTileEntity = getMcBlockAccess().getTileEntity(new BlockPos(x(), y(), z()));
+			mcTileEntity = getMcBlockAccess().getTileEntity(blockPos());
 		}
-		return mcTileEntity;
+		return Optional.ofNullable(mcTileEntity);
 	}
 
 	@Override
@@ -168,23 +179,17 @@ public class BWBlock extends Block implements Storable {
 	@Override
 	public void save(Data data) {
 		Storable.super.save(data);
-
-		TileEntity tileEntity = getTileEntityImpl();
-		if (tileEntity != null) {
+		getTileEntity().ifPresent(tile -> {
 			NBTTagCompound nbt = new NBTTagCompound();
-			tileEntity.writeToNBT(nbt);
-			data.putAll(Game.natives().toNova(nbt));
-		}
+			tile.writeToNBT(nbt);
+			data.putAll(DataConverter.instance().toNova(nbt));
+		});
 	}
 
 	@Override
 	public void load(Data data) {
 		Storable.super.load(data);
-
-		TileEntity tileEntity = getTileEntityImpl();
-		if (tileEntity != null) {
-			tileEntity.writeToNBT(Game.natives().toNative(data));
-		}
+		getTileEntity().ifPresent(tile -> tile.readFromNBT(DataConverter.instance().toNative(data)));
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
@@ -140,6 +140,10 @@ public class BWBlock extends Block implements Storable {
 		return Game.natives().toNova(new ItemStack(Item.getItemFromBlock(mcBlock)));
 	}
 
+	public net.minecraft.block.Block block() {
+		return mcBlock;
+	}
+
 	public BlockPos blockPos() {
 		return VectorConverter.instance().toNative(position());
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
@@ -74,7 +74,7 @@ public class BWBlock extends Block implements Storable {
 		this.mcBlock = block;
 		components.add(new BWBlockTransform(this, world, pos));
 		components.add(new BlockProperty.Opacity().setOpacity(mcBlock.getMaterial().blocksLight() ? 1 : 0));
-		if (mcBlock.isReplaceable((net.minecraft.world.World) getMcBlockAccess(), new BlockPos(x(), y(), z())))
+		if (mcBlock.isReplaceable((net.minecraft.world.World) blockAccess(), new BlockPos(x(), y(), z())))
 			components.add(BlockProperty.Replaceable.instance());
 
 		BlockProperty.BlockSound blockSound = components.add(new BlockProperty.BlockSound());
@@ -82,14 +82,14 @@ public class BWBlock extends Block implements Storable {
 		blockSound.setBlockSound(BlockProperty.BlockSound.BlockSoundTrigger.BREAK, new Sound("", mcBlock.stepSound.getBreakSound()));
 		blockSound.setBlockSound(BlockProperty.BlockSound.BlockSoundTrigger.WALK, new Sound("", mcBlock.stepSound.getStepSound()));
 
-		components.add(new LightEmitter()).setEmittedLevel(() -> mcBlock.getLightValue(getMcBlockAccess(), new BlockPos(x(), y(), z())) / 15.0);
+		components.add(new LightEmitter()).setEmittedLevel(() -> mcBlock.getLightValue(blockAccess(), new BlockPos(x(), y(), z())) / 15.0);
 		components.add(new Collider(this))
 			.setBoundingBox(() -> new Cuboid(mcBlock.getBlockBoundsMinX(), mcBlock.getBlockBoundsMinY(), mcBlock.getBlockBoundsMinZ(), mcBlock.getBlockBoundsMaxX(), mcBlock.getBlockBoundsMaxY(), mcBlock.getBlockBoundsMaxZ()))
 			.setOcclusionBoxes(entity -> {
 				List<AxisAlignedBB> aabbs = new ArrayList<>();
-				if (getMcBlockAccess() instanceof net.minecraft.world.World)
+				if (blockAccess() instanceof net.minecraft.world.World)
 					mcBlock.addCollisionBoxesToList(
-						(net.minecraft.world.World) getMcBlockAccess(),
+						(net.minecraft.world.World) blockAccess(),
 						blockPos(),
 						blockState(),
 						CuboidConverter.instance().toNative(entity
@@ -104,7 +104,7 @@ public class BWBlock extends Block implements Storable {
 					.map(cuboid -> cuboid.subtract(pos))
 					.collect(Collectors.toSet());
 			}).setSelectionBoxes(entity -> {
-				final AxisAlignedBB bb = mcBlock.getSelectedBoundingBox(((net.minecraft.world.World) getMcBlockAccess()), blockPos());
+				final AxisAlignedBB bb = mcBlock.getSelectedBoundingBox(((net.minecraft.world.World) blockAccess()), blockPos());
 				Cuboid cuboid = CuboidConverter.instance().toNova(bb);
 				return Collections.singleton(cuboid.subtract(position()));
 			});
@@ -125,7 +125,7 @@ public class BWBlock extends Block implements Storable {
 					case 3:
 						// model rendering
 						model.addChild(new BWBakedModel(Minecraft.getMinecraft().getBlockRendererDispatcher()
-							.getModelFromBlockState(blockState(), getMcBlockAccess(), blockPos()), DefaultVertexFormats.BLOCK));
+							.getModelFromBlockState(blockState(), blockAccess(), blockPos()), DefaultVertexFormats.BLOCK));
 						break;
 				}
 			});
@@ -144,24 +144,24 @@ public class BWBlock extends Block implements Storable {
 		return VectorConverter.instance().toNative(position());
 	}
 
-	public IBlockAccess getMcBlockAccess() {
+	public IBlockAccess blockAccess() {
 		return WorldConverter.instance().toNative(world());
 	}
 
 	public IBlockState blockState() {
-		return getMcBlockAccess().getBlockState(new BlockPos(x(), y(), z()));
+		return blockAccess().getBlockState(new BlockPos(x(), y(), z()));
 	}
 
 	public Optional<TileEntity> getTileEntity() {
 		if (mcTileEntity == null && mcBlock.hasTileEntity(blockState())) {
-			mcTileEntity = getMcBlockAccess().getTileEntity(blockPos());
+			mcTileEntity = blockAccess().getTileEntity(blockPos());
 		}
 		return Optional.ofNullable(mcTileEntity);
 	}
 
 	@Override
 	public boolean canReplace() {
-		return mcBlock.canPlaceBlockAt((net.minecraft.world.World) getMcBlockAccess(), new BlockPos(x(), y(), z()));
+		return mcBlock.canPlaceBlockAt((net.minecraft.world.World) blockAccess(), new BlockPos(x(), y(), z()));
 	}
 
 	@Override

--- a/src/main/java/nova/core/block/Block.java
+++ b/src/main/java/nova/core/block/Block.java
@@ -43,18 +43,25 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
+ * The class that represents the instance of a block in the world.
+ *
  * @author Calclavia
  */
 public class Block extends SidedComponentProvider implements Identifiable, Translatable {
 
+	/**
+	 * Called to get the {@link ItemFactory} that refers to this Block instance.
+	 *
+	 * @return The {@link ItemFactory} that refers to this Block instance.
+	 */
 	public ItemFactory getItemFactory() {
 		return Game.items().getItemFromBlock(getFactory());
 	}
 
 	/**
-	 * Called to get the BlockFactory that refers to this Block class.
-	 * @return The {@link nova.core.block.BlockFactory} that refers to this
-	 * Block class.
+	 * Called to get the {@link BlockFactory} that refers to this Block class.
+	 *
+	 * @return The {@link BlockFactory} that refers to this Block class.
 	 */
 	public final BlockFactory getFactory() {
 		return (BlockFactory) components.get(FactoryProvider.class).factory;
@@ -75,37 +82,56 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		return LanguageManager.instance().translate(this.getUnlocalizedName() + ".name", this.getReplacements());
 	}
 
+	/**
+	 * Gets the block transformation data.
+	 * ({@link #world() world} and {@link #position() position})
+	 *
+	 * @return The block transformation data
+	 */
 	public final BlockTransform transform() {
 		return components.get(BlockTransform.class);
 	}
 
+	/**
+	 * Gets the world that this block resides in.
+	 *
+	 * @return The world that this block resides in
+	 */
 	public final World world() {
 		return transform().world();
 	}
 
+	/**
+	 * Gets the position of this block in the world.
+	 *
+	 * @return The position of this block
+	 */
 	public final Vector3D position() {
 		return transform().position();
 	}
 
 	/**
-	 * Get the x co-ordinate of the block.
-	 * @return The x co-ordinate of the block.
+	 * Get the {@code X} coordinate of this block.
+	 *
+	 * @return The {@code X} coordinate of this block
 	 */
 	public final long x() {
 		return (long) FastMath.floor(position().getX());
 	}
 
 	/**
-	 * Get the y co-ordinate of the block.
-	 * @return The y co-ordinate of the block.
+	 * Get the {@code Y} coordinate of this block.
+	 *
+	 * @return The {@code Y} coordinate of this block
 	 */
 	public final long y() {
 		return (long) FastMath.floor(position().getY());
 	}
 
 	/**
-	 * Get the z co-ordinate of the block.
-	 * @return The z co-ordinate of the block.
+	 * Get the {@code Z} coordinate of this block.
+	 *
+	 * @return The {@code Z} coordinate of this block
 	 */
 	public final long z() {
 		return (long) FastMath.floor(position().getZ());
@@ -147,8 +173,10 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		return true;
 	}
 
+	// Block Events
+
 	/**
-	 * Block Events
+	 * The event that is called when a block next to this one changes (removed, placed, etc...).
 	 */
 	public static class NeighborChangeEvent extends CancelableEvent {
 		public final Optional<Vector3D> neighborPosition;
@@ -162,6 +190,9 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		}
 	}
 
+	/**
+	 * The event that is called when the block is placed.
+	 */
 	public static class PlaceEvent extends Event {
 
 		/**
@@ -186,6 +217,11 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 
 		/**
 		 * Called when the block is placed.
+		 *
+		 * @param placer The entity that placed the block
+		 * @param side The side placed on
+		 * @param hit Where the entity clicked on the block for placement
+		 * @param item The item used to place this block
 		 */
 		public PlaceEvent(Entity placer, Direction side, Vector3D hit, Item item) {
 			this.placer = placer;
@@ -195,6 +231,9 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		}
 	}
 
+	/**
+	 * The event that is called when the block is about to be removed.
+	 */
 	public static class RemoveEvent extends Event {
 		/**
 		 * The entity that is removing the block
@@ -208,12 +247,17 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 
 		/**
 		 * Called when the block is about to be removed.
+		 *
+		 * @param entity The entity that is removing the block
 		 */
 		public RemoveEvent(Optional<Entity> entity) {
 			this.entity = entity;
 		}
 	}
 
+	/**
+	 * The event that is called when the block is right clicked.
+	 */
 	public static class RightClickEvent extends Event {
 		/**
 		 * The entity that clicked this object. Most likely a
@@ -236,6 +280,13 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		 */
 		public boolean result = false;
 
+		/**
+		 * Called when the block is right clicked.
+		 *
+		 * @param entity The entity that clicked this object
+		 * @param side The side it was clicked
+		 * @param position The position it was clicked
+		 */
 		public RightClickEvent(Entity entity, Direction side, Vector3D position) {
 			this.entity = entity;
 			this.side = side;
@@ -243,6 +294,9 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		}
 	}
 
+	/**
+	 * The event that is called when the block is left clicked.
+	 */
 	public static class LeftClickEvent extends Event {
 		/**
 		 * The entity that clicked this object. Most likely a
@@ -265,6 +319,13 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		 */
 		public boolean result = false;
 
+		/**
+		 * Called when the block is left clicked.
+		 *
+		 * @param entity The entity that clicked this object
+		 * @param side The side it was clicked
+		 * @param position The position it was clicked
+		 */
 		public LeftClickEvent(Entity entity, Direction side, Vector3D position) {
 			this.entity = entity;
 			this.side = side;
@@ -272,10 +333,21 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 		}
 	}
 
+	/**
+	 * The event that is called when the block is broken and it is time to drop it as an item.
+	 */
 	public static class DropEvent extends Event {
 
+		/**
+		 * The set of items to drop.
+		 */
 		public Set<Item> drops;
 
+		/**
+		 * Called when the block is broken and it is time to drop it as an item.
+		 *
+		 * @param block The block that was broken.
+		 */
 		public DropEvent(Block block) {
 			this.drops = Collections.singleton(block.getItemFactory().build());
 		}

--- a/src/main/java/nova/core/block/Block.java
+++ b/src/main/java/nova/core/block/Block.java
@@ -91,24 +91,24 @@ public class Block extends SidedComponentProvider implements Identifiable, Trans
 	 * Get the x co-ordinate of the block.
 	 * @return The x co-ordinate of the block.
 	 */
-	public final int x() {
-		return (int) FastMath.floor(position().getX());
+	public final long x() {
+		return (long) FastMath.floor(position().getX());
 	}
 
 	/**
 	 * Get the y co-ordinate of the block.
 	 * @return The y co-ordinate of the block.
 	 */
-	public final int y() {
-		return (int) FastMath.floor(position().getY());
+	public final long y() {
+		return (long) FastMath.floor(position().getY());
 	}
 
 	/**
 	 * Get the z co-ordinate of the block.
 	 * @return The z co-ordinate of the block.
 	 */
-	public final int z() {
-		return (int) FastMath.floor(position().getZ());
+	public final long z() {
+		return (long) FastMath.floor(position().getZ());
 	}
 
 	/**

--- a/src/main/java/nova/core/util/math/MathUtil.java
+++ b/src/main/java/nova/core/util/math/MathUtil.java
@@ -114,6 +114,84 @@ public class MathUtil {
 	 * @param b value.
 	 * @return min
 	 */
+	public static long min(long a, long b) {
+		return a < b ? a : b;
+	}
+
+	/**
+	 * Returns the smaller number of a, b and c.
+	 * @param a value.
+	 * @param b value.
+	 * @param c value.
+	 * @return min
+	 */
+	public static long min(long a, long b, long c) {
+		return min(min(a, b), c);
+	}
+
+	/**
+	 * Returns the smallest number contained in the provided array.
+	 * @param numbers Array of numbers
+	 * @return min
+	 */
+	public static long min(long... numbers) {
+		if (numbers.length < 1) {
+			throw new IllegalArgumentException();
+		}
+		long min = numbers[0];
+		for (int i = 1; i < numbers.length; i++) {
+			if (numbers[i] < min) {
+				min = numbers[i];
+			}
+		}
+		return min;
+	}
+
+	/**
+	 * Returns the bigger number of a and b.
+	 * @param a value.
+	 * @param b value.
+	 * @return max
+	 */
+	public static long max(long a, long b) {
+		return a > b ? a : b;
+	}
+
+	/**
+	 * Returns the bigger number of a, b and c.
+	 * @param a value.
+	 * @param b value.
+	 * @param c value.
+	 * @return max
+	 */
+	public static long max(long a, long b, long c) {
+		return max(max(a, b), c);
+	}
+
+	/**
+	 * Returns the biggest number contained in the provided array.
+	 * @param numbers Array of numbers
+	 * @return max
+	 */
+	public static long max(long... numbers) {
+		if (numbers.length < 1) {
+			throw new IllegalArgumentException();
+		}
+		long max = numbers[0];
+		for (int i = 1; i < numbers.length; i++) {
+			if (numbers[i] > max) {
+				max = numbers[i];
+			}
+		}
+		return max;
+	}
+
+	/**
+	 * Returns the smaller number of a and b.
+	 * @param a value.
+	 * @param b value.
+	 * @return min
+	 */
 	public static double min(double a, double b) {
 		return a < b ? a : b;
 	}
@@ -263,7 +341,7 @@ public class MathUtil {
 		}
 		return max;
 	}
-	
+
 	/**
 	 * Clamps the given number so that {@code min <= a <= max}
 	 * @param a value.
@@ -282,7 +360,29 @@ public class MathUtil {
 	 * @param max upper limit
 	 * @return {@code min <= a <= max}
 	 */
+	public static long clamp(long a, long min, long max) {
+		return min(max(a, min), max);
+	}
+
+	/**
+	 * Clamps the given number so that {@code min <= a <= max}
+	 * @param a value
+	 * @param min lower limit
+	 * @param max upper limit
+	 * @return {@code min <= a <= max}
+	 */
 	public static double clamp(double a, double min, double max) {
+		return min(max(a, min), max);
+	}
+
+	/**
+	 * Clamps the given number so that {@code min <= a <= max}
+	 * @param a value.
+	 * @param min lower limit
+	 * @param max upper limit
+	 * @return {@code min <= a <= max}
+	 */
+	public static float clamp(float a, float min, float max) {
 		return min(max(a, min), max);
 	}
 
@@ -297,24 +397,70 @@ public class MathUtil {
 		return a + f * (b - a);
 	}
 
+	/**
+	 * Linear interpolates isBetween point a and point b
+	 * @param a value.
+	 * @param b value.
+	 * @param f A percentage value isBetween 0 to 1
+	 * @return The interpolated value
+	 */
 	public static float lerp(float a, float b, float f) {
 		return a + f * (b - a);
 	}
 
+	/**
+	 * Linear interpolates isBetween point a and point b
+	 * @param a value.
+	 * @param b value.
+	 * @param f A percentage value isBetween 0 to 1
+	 * @return The interpolated value
+	 */
 	public static Vector3D lerp(Vector3D a, Vector3D b, float f) {
 		return a.add((b.subtract(a)).scalarMultiply(f));
 	}
 
 	/**
-	 * Clamps a value isBetween -bounds to +bounds
-	 * @return A value capped isBetween two bounds.
+	 * Clamps a value between -bounds to +bounds.
+	 *
+	 * @param value The value
+	 * @param bounds The maximum distance from 0
+	 * @return A value clamped between two bounds
 	 */
-	public static double absClamp(double value, double bounds) {
-		return min(max(value, -bounds), bounds);
+	public static int absClamp(int value, int bounds) {
+		return clamp(value, -bounds, bounds);
 	}
 
-	public static float absClamp(int value, int bounds) {
-		return min(max(value, -bounds), bounds);
+	/**
+	 * Clamps a value between -bounds to +bounds.
+	 *
+	 * @param value The value
+	 * @param bounds The maximum distance from 0
+	 * @return A value clamped between two bounds
+	 */
+	public static long absClamp(long value, long bounds) {
+		return clamp(value, -bounds, bounds);
+	}
+
+	/**
+	 * Clamps a value between -bounds to +bounds.
+	 *
+	 * @param value The value
+	 * @param bounds The maximum distance from 0
+	 * @return A value clamped between two bounds
+	 */
+	public static double absClamp(double value, double bounds) {
+		return clamp(value, -bounds, bounds);
+	}
+
+	/**
+	 * Clamps a value between -bounds to +bounds.
+	 *
+	 * @param value The value
+	 * @param bounds The maximum distance from 0
+	 * @return A value clamped between two bounds
+	 */
+	public static float absClamp(float value, float bounds) {
+		return clamp(value, -bounds, bounds);
 	}
 
 	public static double truncate(double value, int truncation) {
@@ -325,8 +471,16 @@ public class MathUtil {
 		return (int) (Math.log(x) / Math.log(base));
 	}
 
+	public static long log(long x, long base) {
+		return (long) (Math.log(x) / Math.log(base));
+	}
+
 	public static double log(double x, double base) {
 		return Math.log(x) / Math.log(base);
+	}
+
+	public static float log(float x, float base) {
+		return (float) (Math.log(x) / Math.log(base));
 	}
 
 	/**
@@ -339,4 +493,22 @@ public class MathUtil {
 		return a <= x && x <= b;
 	}
 
+	/**
+	 * Rounds a number to a specific number place places
+	 *
+	 * @param d - the number
+	 * @param decimalPlaces The decimal places
+	 * @return The rounded number
+	 */
+	public static double roundDecimals(double d, int decimalPlaces) {
+		double pow = Math.pow(10, decimalPlaces);
+		long i = Math.round(d * pow);
+		return i / pow;
+	}
+
+	public static String toString(double d, boolean removeTrailingZeroes) {
+		if (removeTrailingZeroes && d % 1 == 0)
+			return Long.toString((long) d);
+		return Double.toString(d);
+	}
 }

--- a/src/test/java/nova/core/util/math/MathUtilTest.java
+++ b/src/test/java/nova/core/util/math/MathUtilTest.java
@@ -23,69 +23,105 @@ package nova.core.util.math;
 
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.assertj.core.data.Offset;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static nova.testutils.NovaAssertions.assertThat;
-
 
 /**
  * @author Kubuxu
  */
 
 public class MathUtilTest {
+	@BeforeClass
+	public static void hiddenConstructor() {
+		try {
+			// Needed for 100% code coverage because MathUtil has a private constructor as it is a utility class.
+			java.lang.reflect.Constructor<MathUtil> c = MathUtil.class.getDeclaredConstructor();
+			c.setAccessible(true);
+			c.newInstance();
+			c.setAccessible(false);
+		} catch (Exception e) {}
+	}
+
+	@Override
+	public String toString() {
+		return super.toString(); //To change body of generated methods, choose Tools | Templates.
+	}
+
     @Test
     public void testMax() {
-        assertThat(MathUtil.max(1,2)).isEqualTo(2);
-        assertThat(MathUtil.max(2,1)).isEqualTo(2);
+        assertThat(MathUtil.max(1, 2)).isEqualTo(2);
+        assertThat(MathUtil.max(2, 1)).isEqualTo(2);
 
-        assertThat(MathUtil.max(0,1,2)).isEqualTo(2);
-        assertThat(MathUtil.max(0,2,1)).isEqualTo(2);
-        assertThat(MathUtil.max(2,0,1)).isEqualTo(2);
+        assertThat(MathUtil.max(0, 1, 2)).isEqualTo(2);
+        assertThat(MathUtil.max(0, 2, 1)).isEqualTo(2);
+        assertThat(MathUtil.max(2, 0, 1)).isEqualTo(2);
 
-        assertThat(MathUtil.max(0,1,2,4)).isEqualTo(4);
-        assertThat(MathUtil.max(0,4,2,1)).isEqualTo(4);
-        assertThat(MathUtil.max(4,2,0,1)).isEqualTo(4);
+        assertThat(MathUtil.max(0, 1, 2, 4)).isEqualTo(4);
+        assertThat(MathUtil.max(0, 4, 2, 1)).isEqualTo(4);
+        assertThat(MathUtil.max(4, 2, 0, 1)).isEqualTo(4);
 
-        assertThat(MathUtil.max(1d,2d)).isEqualTo(2d);
-        assertThat(MathUtil.max(2d,1d)).isEqualTo(2d);
+        assertThat(MathUtil.max(1l, 2l)).isEqualTo(2l);
+        assertThat(MathUtil.max(2l, 1l)).isEqualTo(2l);
 
-        assertThat(MathUtil.max(0d,1d,2d)).isEqualTo(2d);
-        assertThat(MathUtil.max(0d,2d,1d)).isEqualTo(2d);
-        assertThat(MathUtil.max(2d,0d,1d)).isEqualTo(2d);
+        assertThat(MathUtil.max(0l, 1l, 2l)).isEqualTo(2l);
+        assertThat(MathUtil.max(0l, 2l, 1l)).isEqualTo(2l);
+        assertThat(MathUtil.max(2l, 0l, 1l)).isEqualTo(2l);
 
-        assertThat(MathUtil.max(0d,1d,2d,4d)).isEqualTo(4d);
-        assertThat(MathUtil.max(0d,4d,2d,1d)).isEqualTo(4d);
-        assertThat(MathUtil.max(4d,2d,0d,1d)).isEqualTo(4d);
+        assertThat(MathUtil.max(0l, 1l, 2l, 4l)).isEqualTo(4l);
+        assertThat(MathUtil.max(0l, 4l, 2l, 1l)).isEqualTo(4l);
+        assertThat(MathUtil.max(4l, 2l, 0l, 1l)).isEqualTo(4l);
 
-	    assertThat(MathUtil.max(1d,2d)).isEqualTo(2d);
-	    assertThat(MathUtil.max(2d,1d)).isEqualTo(2d);
+        assertThat(MathUtil.max(1d, 2d)).isEqualTo(2d);
+        assertThat(MathUtil.max(2d, 1d)).isEqualTo(2d);
 
-	    assertThat(MathUtil.max(0f,1f,2f)).isEqualTo(2f);
-	    assertThat(MathUtil.max(0f,2f,1f)).isEqualTo(2f);
-	    assertThat(MathUtil.max(2f,0f,1f)).isEqualTo(2f);
+        assertThat(MathUtil.max(0d, 1d, 2d)).isEqualTo(2d);
+        assertThat(MathUtil.max(0d, 2d, 1d)).isEqualTo(2d);
+        assertThat(MathUtil.max(2d, 0d, 1d)).isEqualTo(2d);
 
-	    assertThat(MathUtil.max(0f,1f,2f,4f)).isEqualTo(4f);
-	    assertThat(MathUtil.max(0f,4f,2f,1f)).isEqualTo(4f);
-	    assertThat(MathUtil.max(4f,2f,0f,1f)).isEqualTo(4f);
+        assertThat(MathUtil.max(0d, 1d, 2d, 4d)).isEqualTo(4d);
+        assertThat(MathUtil.max(0d, 4d, 2d, 1d)).isEqualTo(4d);
+        assertThat(MathUtil.max(4d, 2d, 0d, 1d)).isEqualTo(4d);
+
+	    assertThat(MathUtil.max(1d, 2d)).isEqualTo(2d);
+	    assertThat(MathUtil.max(2d, 1d)).isEqualTo(2d);
+
+	    assertThat(MathUtil.max(0f, 1f, 2f)).isEqualTo(2f);
+	    assertThat(MathUtil.max(0f, 2f, 1f)).isEqualTo(2f);
+	    assertThat(MathUtil.max(2f, 0f, 1f)).isEqualTo(2f);
+
+	    assertThat(MathUtil.max(0f, 1f, 2f, 4f)).isEqualTo(4f);
+	    assertThat(MathUtil.max(0f, 4f, 2f, 1f)).isEqualTo(4f);
+	    assertThat(MathUtil.max(4f, 2f, 0f, 1f)).isEqualTo(4f);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testMaxError() {
-        MathUtil.max();
-
+    public void testMaxErrorInt() {
+        MathUtil.max(new int[]{});
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaxErrorLong() {
+        MathUtil.max(new long[]{});
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testMaxErrorDouble() {
         MathUtil.max(new double[]{});
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaxErrorFloat() {
+        MathUtil.max(new float[]{});
+    }
 
     @Test
     public void testMin() {
         assertThat(MathUtil.min(1, 2)).isEqualTo(1);
         assertThat(MathUtil.min(2, 1)).isEqualTo(1);
 
-        assertThat(MathUtil.min(0,1,2)).isEqualTo(0);
+        assertThat(MathUtil.min(0, 1, 2)).isEqualTo(0);
         assertThat(MathUtil.min(0, 2, 1)).isEqualTo(0);
         assertThat(MathUtil.min(2, 0, 1)).isEqualTo(0);
 
@@ -93,21 +129,32 @@ public class MathUtilTest {
         assertThat(MathUtil.min(0, 4, 2, 1)).isEqualTo(0);
         assertThat(MathUtil.min(4, 2, 0, 1)).isEqualTo(0);
 
+        assertThat(MathUtil.min(1l, 2l)).isEqualTo(1l);
+        assertThat(MathUtil.min(2l, 1l)).isEqualTo(1l);
+
+        assertThat(MathUtil.min(0l, 1l, 2l)).isEqualTo(0l);
+        assertThat(MathUtil.min(0l, 2l, 1l)).isEqualTo(0l);
+        assertThat(MathUtil.min(2l, 0l, 1l)).isEqualTo(0l);
+
+        assertThat(MathUtil.min(0l, 1l, 2l, 4l)).isEqualTo(0l);
+        assertThat(MathUtil.min(0l, 4l, 2l, 1l)).isEqualTo(0l);
+        assertThat(MathUtil.min(4l, 2l, 0l, 1l)).isEqualTo(0l);
+
         assertThat(MathUtil.min(1d, 2d)).isEqualTo(1d);
         assertThat(MathUtil.min(2d, 1d)).isEqualTo(1d);
 
-        assertThat(MathUtil.min(0d,1d,2d)).isEqualTo(0d);
+        assertThat(MathUtil.min(0d, 1d, 2d)).isEqualTo(0d);
         assertThat(MathUtil.min(0d, 2d, 1d)).isEqualTo(0d);
         assertThat(MathUtil.min(2d, 0d, 1d)).isEqualTo(0d);
 
         assertThat(MathUtil.min(0d, 1d, 2d, 4d)).isEqualTo(0d);
         assertThat(MathUtil.min(0d, 4d, 2d, 1d)).isEqualTo(0d);
         assertThat(MathUtil.min(4d, 2d, 0d, 1d)).isEqualTo(0d);
-	    
+
 	    assertThat(MathUtil.min(1f, 2f)).isEqualTo(1f);
 	    assertThat(MathUtil.min(2f, 1f)).isEqualTo(1f);
 
-	    assertThat(MathUtil.min(0f,1f,2f)).isEqualTo(0f);
+	    assertThat(MathUtil.min(0f, 1f, 2f)).isEqualTo(0f);
 	    assertThat(MathUtil.min(0f, 2f, 1f)).isEqualTo(0f);
 	    assertThat(MathUtil.min(2f, 0f, 1f)).isEqualTo(0f);
 
@@ -117,13 +164,23 @@ public class MathUtilTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testMinError() {
-        MathUtil.min();
+    public void testMinErrorInt() {
+        MathUtil.min(new int[]{});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMinErrorLong() {
+        MathUtil.min(new long[]{});
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMinErrorDouble() {
         MathUtil.min(new double[]{});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMinErrorFloat() {
+        MathUtil.min(new float[]{});
     }
 
     @Test
@@ -133,10 +190,47 @@ public class MathUtilTest {
 	    assertThat(MathUtil.clamp(3, 2, 3)).isEqualTo(3);
 	    assertThat(MathUtil.clamp(1, 2, 3)).isEqualTo(2);
 
-	    assertThat(MathUtil.clamp(6D, 2, 3)).isEqualTo(3);
-	    assertThat(MathUtil.clamp(2D, 2, 3)).isEqualTo(2);
-	    assertThat(MathUtil.clamp(3D, 2, 3)).isEqualTo(3);
-	    assertThat(MathUtil.clamp(1D, 2, 3)).isEqualTo(2);
+	    assertThat(MathUtil.clamp(6l, 2l, 3l)).isEqualTo(3l);
+	    assertThat(MathUtil.clamp(2l, 2l, 3l)).isEqualTo(2l);
+	    assertThat(MathUtil.clamp(3l, 2l, 3l)).isEqualTo(3l);
+	    assertThat(MathUtil.clamp(1l, 2l, 3l)).isEqualTo(2l);
+
+	    assertThat(MathUtil.clamp(6d, 2d, 3d)).isEqualTo(3);
+	    assertThat(MathUtil.clamp(2d, 2d, 3d)).isEqualTo(2);
+	    assertThat(MathUtil.clamp(3d, 2d, 3d)).isEqualTo(3);
+	    assertThat(MathUtil.clamp(1d, 2d, 3d)).isEqualTo(2);
+
+	    assertThat(MathUtil.clamp(6f, 2f, 3f)).isEqualTo(3);
+	    assertThat(MathUtil.clamp(2f, 2f, 3f)).isEqualTo(2);
+	    assertThat(MathUtil.clamp(3f, 2f, 3f)).isEqualTo(3);
+	    assertThat(MathUtil.clamp(1f, 2f, 3f)).isEqualTo(2);
+    }
+
+    @Test
+    public void testAbsClamp() {
+	    assertThat(MathUtil.absClamp( 2, 1)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 1, 1)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 0, 1)).isEqualTo( 0);
+	    assertThat(MathUtil.absClamp(-1, 1)).isEqualTo(-1);
+	    assertThat(MathUtil.absClamp(-2, 1)).isEqualTo(-1);
+
+	    assertThat(MathUtil.absClamp( 2l, 1l)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 1l, 1l)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 0l, 1l)).isEqualTo( 0);
+	    assertThat(MathUtil.absClamp(-1l, 1l)).isEqualTo(-1);
+	    assertThat(MathUtil.absClamp(-2l, 1l)).isEqualTo(-1);
+
+	    assertThat(MathUtil.absClamp( 2d, 1d)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 1d, 1d)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 0d, 1d)).isEqualTo( 0);
+	    assertThat(MathUtil.absClamp(-1d, 1d)).isEqualTo(-1);
+	    assertThat(MathUtil.absClamp(-2d, 1d)).isEqualTo(-1);
+
+	    assertThat(MathUtil.absClamp( 2f, 1f)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 1f, 1f)).isEqualTo( 1);
+	    assertThat(MathUtil.absClamp( 0f, 1f)).isEqualTo( 0);
+	    assertThat(MathUtil.absClamp(-1f, 1f)).isEqualTo(-1);
+	    assertThat(MathUtil.absClamp(-2f, 1f)).isEqualTo(-1);
     }
 
 	@Test
@@ -156,5 +250,36 @@ public class MathUtilTest {
 		assertThat(MathUtil.lerp(Vector3D.ZERO, Vector3DUtil.ONE, 1)).isAlmostEqualTo(Vector3DUtil.ONE);
 	}
 
+	@Test
+	public void testLog() {
+		assertThat(MathUtil.log(1, 2)).isEqualTo(0);
+		assertThat(MathUtil.log(1l, 2l)).isEqualTo(0);
+		assertThat(MathUtil.log(1d, 2d)).isEqualTo(0);
+		assertThat(MathUtil.log(1f, 2f)).isEqualTo(0);
+	}
+
+	@Test
+	public void testRoundDecimals() {
+		assertThat(MathUtil.roundDecimals(10, 0)).isEqualTo(10);
+		assertThat(MathUtil.roundDecimals(10.5, 0)).isEqualTo(11);
+		assertThat(MathUtil.roundDecimals(11, 0)).isEqualTo(11);
+	}
+
+	@Test
+	public void testBetween() {
+		assertThat(MathUtil.isBetween(1, 0, 3)).isFalse();
+		assertThat(MathUtil.isBetween(1, 2, 3)).isTrue();
+		assertThat(MathUtil.isBetween(1, 4, 3)).isFalse();
+	}
+
+	@Test
+	public void testToString() {
+		assertThat(MathUtil.toString(0, false)).isEqualTo("0.0");
+		assertThat(MathUtil.toString(0.5, false)).isEqualTo("0.5");
+		assertThat(MathUtil.toString(1, false)).isEqualTo("1.0");
+		assertThat(MathUtil.toString(0, true)).isEqualTo("0");
+		assertThat(MathUtil.toString(0.5, true)).isEqualTo("0.5");
+		assertThat(MathUtil.toString(1, true)).isEqualTo("1");
+	}
 }
 


### PR DESCRIPTION
This PR changes the Block coordinate methods (`x()`, `y()` and `z()`) return type to `long`.
This is needed for [SuperNOVA](https://github.com/NOVA-Team/SuperNOVA) and other voxel based games, which have larger worlds than Minecraft.

---

### Additional changes/fixes:

- Changed `BWBlock.getMcBlockAccess()` to `BWBlock.blockAccess()`
- Added `BWBlock.blockPos()` in MC 1.8
- Merged `BWBlock.getTileEntity()` and `BWBlock.getTileEntityImpl()`
- Fixed `BWBlock.load(Data)`