### PR TITLE
Change Player ID methods and their meaning

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/backward/BWEntity.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/backward/BWEntity.java
@@ -92,18 +92,18 @@ public class BWEntity extends Entity {
 		}
 
 		@Override
-		public String getUsername() {
-			return entity.getGameProfile().getName();
-		}
-
-		@Override
-		public String getID() {
+		public String getUniqueID() {
 			return entity.getGameProfile().getId().toString();
 		}
 
 		@Override
 		public InventoryPlayer getInventory() {
 			return inventory;
+		}
+
+		@Override
+		public String getUsername() {
+			return entity.getGameProfile().getName();
 		}
 
 		@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntity.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntity.java
@@ -61,7 +61,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 	@Override
 	protected void readEntityFromNBT(NBTTagCompound nbt) {
 		if (wrapped instanceof Storable && nbt.hasKey("nova")) {
-			((Storable) wrapped).load(Game.natives().toNova(nbt.getCompoundTag("nova")));
+			((Storable) wrapped).load(DataConverter.instance().toNova(nbt.getCompoundTag("nova")));
 		}
 		if (wrapped == null) {
 			//This entity was saved to disk.
@@ -74,7 +74,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 		if (wrapped instanceof Storable) {
 			Data data = new Data();
 			((Storable) wrapped).save(data);
-			nbt.setTag("nova", Game.natives().toNative(data));
+			nbt.setTag("nova", DataConverter.instance().toNative(data));
 		}
 		nbt.setString("novaID", wrapped.getID());
 	}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/MCEntityTransform.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/MCEntityTransform.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v17.wrapper.entity.forward;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.DimensionManager;
 import nova.core.component.transform.EntityTransform;
+import nova.core.util.UniqueIdentifiable;
 import nova.core.util.math.RotationUtil;
 import nova.core.util.math.Vector3DUtil;
 import nova.core.world.World;
@@ -36,7 +37,7 @@ import java.util.Arrays;
  * Wraps Transform3d used in entity
  * @author Calclavia
  */
-public class MCEntityTransform extends EntityTransform {
+public class MCEntityTransform extends EntityTransform implements UniqueIdentifiable {
 	public final net.minecraft.entity.Entity wrapper;
 
 	public MCEntityTransform(net.minecraft.entity.Entity wrapper) {
@@ -86,5 +87,10 @@ public class MCEntityTransform extends EntityTransform {
 		double[] euler = rotation.getAngles(RotationUtil.DEFAULT_ORDER);
 		wrapper.rotationYaw = (float) Math.toDegrees(euler[0]);
 		wrapper.rotationPitch = (float) Math.toDegrees(euler[1]);
+	}
+
+	@Override
+	public String getUniqueID() {
+		return wrapper.getUniqueID().toString();
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/backward/BWEntity.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/backward/BWEntity.java
@@ -92,18 +92,18 @@ public class BWEntity extends Entity {
 		}
 
 		@Override
-		public String getUsername() {
-			return entity.getGameProfile().getName();
-		}
-
-		@Override
-		public String getID() {
+		public String getUniqueID() {
 			return entity.getGameProfile().getId().toString();
 		}
 
 		@Override
 		public InventoryPlayer getInventory() {
 			return inventory;
+		}
+
+		@Override
+		public String getUsername() {
+			return entity.getGameProfile().getName();
 		}
 
 		@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntity.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntity.java
@@ -61,7 +61,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 	@Override
 	protected void readEntityFromNBT(NBTTagCompound nbt) {
 		if (wrapped instanceof Storable && nbt.hasKey("nova")) {
-			((Storable) wrapped).load(Game.natives().toNova(nbt.getCompoundTag("nova")));
+			((Storable) wrapped).load(DataConverter.instance().toNova(nbt.getCompoundTag("nova")));
 		}
 		if (wrapped == null) {
 			//This entity was saved to disk.
@@ -74,7 +74,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 		if (wrapped instanceof Storable) {
 			Data data = new Data();
 			((Storable) wrapped).save(data);
-			nbt.setTag("nova", Game.natives().toNative(data));
+			nbt.setTag("nova", DataConverter.instance().toNative(data));
 		}
 		nbt.setString("novaID", wrapped.getID());
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/MCEntityTransform.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/MCEntityTransform.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v18.wrapper.entity.forward;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.DimensionManager;
 import nova.core.component.transform.EntityTransform;
+import nova.core.util.UniqueIdentifiable;
 import nova.core.util.math.RotationUtil;
 import nova.core.util.math.Vector3DUtil;
 import nova.core.world.World;
@@ -36,7 +37,7 @@ import java.util.Arrays;
  * Wraps Transform3d used in entity
  * @author Calclavia
  */
-public class MCEntityTransform extends EntityTransform {
+public class MCEntityTransform extends EntityTransform implements UniqueIdentifiable {
 	public final net.minecraft.entity.Entity wrapper;
 
 	public MCEntityTransform(net.minecraft.entity.Entity wrapper) {
@@ -86,5 +87,10 @@ public class MCEntityTransform extends EntityTransform {
 		double[] euler = rotation.getAngles(RotationUtil.DEFAULT_ORDER);
 		wrapper.rotationYaw = (float) Math.toDegrees(euler[0]);
 		wrapper.rotationPitch = (float) Math.toDegrees(euler[1]);
+	}
+
+	@Override
+	public String getUniqueID() {
+		return wrapper.getUniqueID().toString();
 	}
 }

--- a/src/main/java/nova/core/component/Component.java
+++ b/src/main/java/nova/core/component/Component.java
@@ -56,6 +56,11 @@ public abstract class Component implements Identifiable {
 
 	}
 
+	/**
+	 * Gets the ID that represents this Component type.
+	 *
+	 * @return The ID that represents this Component type.
+	 */
 	@Override
 	public String getID() {
 		return getClass().getSimpleName();

--- a/src/main/java/nova/core/entity/Entity.java
+++ b/src/main/java/nova/core/entity/Entity.java
@@ -25,11 +25,14 @@ import nova.core.component.ComponentMap;
 import nova.core.component.ComponentProvider;
 import nova.core.component.misc.FactoryProvider;
 import nova.core.component.transform.EntityTransform;
+import nova.core.entity.component.Player;
 import nova.core.util.Identifiable;
 import nova.core.util.UniqueIdentifiable;
 import nova.core.world.World;
 import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+
+import java.util.Set;
 
 /**
  * An entity is an object in the world that has a position.
@@ -104,6 +107,16 @@ public class Entity extends ComponentProvider<ComponentMap> implements UniqueIde
 
 	@Override
 	public String getUniqueID() {
-		return components.get(UniqueIdentifiable.class).getUniqueID();
+		Set<UniqueIdentifiable> ui = components.getSet(UniqueIdentifiable.class);
+		if (ui.size() == 1) {
+			return ui.iterator().next().getUniqueID(); // Just get the first instance.
+		} else if (ui.size() > 1) {
+			return ui.stream()	// Stream iterate over the whole set
+				.filter(s -> s instanceof Player).findFirst()	// If we have a player component, then prefer that over anything else,
+				.map(UniqueIdentifiable::getUniqueID)	// as the player UUID is usually preferable over anything else.
+				.orElseGet(() -> ui.iterator().next().getUniqueID());	// If we don't have a player component, just use the first UUID we can find.
+		} else {
+			return getID(); // As a fallback, if all else fails, just use the generic entity ID.
+		}
 	}
 }

--- a/src/main/java/nova/core/entity/component/Player.java
+++ b/src/main/java/nova/core/entity/component/Player.java
@@ -23,37 +23,60 @@ package nova.core.entity.component;
 import nova.core.component.UnsidedComponent;
 import nova.core.component.inventory.InventoryPlayer;
 import nova.core.entity.Entity;
+import nova.core.util.UniqueIdentifiable;
 
 /**
- * Basic representation of Player
+ * Basic representation of a Player.
  */
 @UnsidedComponent
-public abstract class Player extends Living {
-	/**
-	 * @return Returns player name that can be used to identify this player
-	 */
-	public abstract String getUsername();
+public abstract class Player extends Living implements UniqueIdentifiable {
 
 	/**
+	 * Get the entity that represents this player.
+	 *
 	 * @return The entity of the player
 	 */
 	public abstract Entity entity();
 
 	/**
-	 * @return Returns the ID representing the player.
-	 * For many games, the username is the ID.
+	 * Get the unique ID for this player. This ID is only
+	 * unique in the context of the game in which
+	 * the current NOVA instance is run.
+	 * <p>
+	 * No guarantees are made about cross-game ID uniqueness.
+	 *
+	 * @return Returns the unique ID representing the player
 	 */
-	public String getPlayerID() {
-		return getUsername();
-	}
+	@Override
+	public abstract String getUniqueID();
 
 	/**
+	 * Get the player's inventory.
+	 *
 	 * @return Inventory of the player
 	 */
 	public abstract InventoryPlayer getInventory();
 
 	/**
-	 * @return Returns non-identifying player name
+	 * Get the player's username.
+	 * <p>
+	 * The difference between this and {@link #getDisplayName()}
+	 * is that the name returned by this method is undecorated,
+	 * while name returned by {@link #getDisplayName()}
+	 * may be decorated.
+	 *
+	 * @return Returns the undecorated non-identifying player name
+	 */
+	public abstract String getUsername();
+
+	/**
+	 * Get the player's display name.
+	 * <p>
+	 * The difference between this and {@link #getUsername()}
+	 * is that the name returned by this method may be decorated,
+	 * while {@link #getUsername()} returns the undecorated name.
+	 *
+	 * @return Returns the decorated non-identifying player name
 	 */
 	public String getDisplayName() {
 		return getUsername();

--- a/src/main/java/nova/core/util/UniqueIdentifiable.java
+++ b/src/main/java/nova/core/util/UniqueIdentifiable.java
@@ -24,7 +24,13 @@ package nova.core.util;
  * A generic interface signifying that this object is uniquely identifiable
  * by an ID
  */
-public interface UniqueIdentifiable {
+public interface UniqueIdentifiable extends Identifiable {
+
+	@Override
+	default String getID() {
+		return getUniqueID();
+	}
+
 	/**
 	 * Get the unique ID to identify this object.
 	 *


### PR DESCRIPTION
The way player IDs are currently implemented is counter-intuitive.
This PR changes the following:

| Method | Old Meaning | New Meaning |
|----------|-------------------|----------------|
| `getUsername()` + `getPlayerID()` → `getUniqueID()` | The username of the player (can be changed in Minecraft) | The unique ID for that specific account in the game on which the mod was installed (will never change) |
| `getID()` | In Minecraft: the unique Mojang account UUID | The ID specific to that component (identifying it from other components, as that is what it's used as by the `Component` class) |
| `getDisplayName()` → `getUsername()` + `getDisplayName()` | Get the player's name displayed in the chat and other places | (Unchanged)