### PR TITLE
Replace `System.currentTimeMillis()` with `System.nanoTime()`

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/MCRetentionManager.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/MCRetentionManager.java
@@ -45,7 +45,7 @@ public class MCRetentionManager extends RetentionManager {
 	/**
 	 * Last time that the queueSave manager tried to queueSave a file
 	 */
-	private long lastSaveMills = 0;
+	private long lastSaveTime = 0;
 
 	/**
 	 * Save all storable queued
@@ -156,8 +156,8 @@ public class MCRetentionManager extends RetentionManager {
 	@SubscribeEvent
 	public void worldSave(WorldEvent evt) {
 		//Current time milli-seconds is used to prevent the files from saving 20 times when the world loads
-		if (System.currentTimeMillis() - lastSaveMills > 2000) {
-			lastSaveMills = System.currentTimeMillis();
+		if (System.nanoTime() - lastSaveTime > 2_000_000_000) {
+			lastSaveTime = System.nanoTime();
 			saveAll();
 		}
 	}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/recipes/MinecraftRecipeRegistry.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/recipes/MinecraftRecipeRegistry.java
@@ -61,7 +61,7 @@ public class MinecraftRecipeRegistry {
 	}
 
 	public void registerRecipes() {
-		long startTime = System.currentTimeMillis();
+		long startTime = System.nanoTime();
 
 		RecipeManager recipeManager = Game.recipes();
 
@@ -78,7 +78,7 @@ public class MinecraftRecipeRegistry {
 
 		ReflectionUtil.setCraftingRecipeList(new RecipeListWrapper(recipes));
 
-		Game.logger().info("Initialized recipes in {} ms", (System.currentTimeMillis() - startTime));
+		Game.logger().info("Initialized recipes in {} ms", (System.nanoTime() - startTime) / 1_000_000);
 
 		recipeManager.whenRecipeAdded(CraftingRecipe.class, this::onNOVARecipeAdded);
 		recipeManager.whenRecipeRemoved(CraftingRecipe.class, this::onNOVARecipeRemoved);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/manager/MCRetentionManager.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/manager/MCRetentionManager.java
@@ -45,7 +45,7 @@ public class MCRetentionManager extends RetentionManager {
 	/**
 	 * Last time that the queueSave manager tried to queueSave a file
 	 */
-	private long lastSaveMills = 0;
+	private long lastSaveTime = 0;
 
 	/**
 	 * Save all storable queued
@@ -156,8 +156,8 @@ public class MCRetentionManager extends RetentionManager {
 	@SubscribeEvent
 	public void worldSave(WorldEvent evt) {
 		//Current time milli-seconds is used to prevent the files from saving 20 times when the world loads
-		if (System.currentTimeMillis() - lastSaveMills > 2000) {
-			lastSaveMills = System.currentTimeMillis();
+		if (System.nanoTime() - lastSaveTime > 2_000_000_000) {
+			lastSaveTime = System.nanoTime();
 			saveAll();
 		}
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/recipes/MinecraftRecipeRegistry.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/recipes/MinecraftRecipeRegistry.java
@@ -61,7 +61,7 @@ public class MinecraftRecipeRegistry {
 	}
 
 	public void registerRecipes() {
-		long startTime = System.currentTimeMillis();
+		long startTime = System.nanoTime();
 
 		RecipeManager recipeManager = Game.recipes();
 
@@ -78,7 +78,7 @@ public class MinecraftRecipeRegistry {
 
 		ReflectionUtil.setCraftingRecipeList(new RecipeListWrapper(recipes));
 
-		Game.logger().info("Initialized recipes in {} ms", (System.currentTimeMillis() - startTime));
+		Game.logger().info("Initialized recipes in {} ms", (System.nanoTime() - startTime) / 1_000_000);
 
 		recipeManager.whenRecipeAdded(CraftingRecipe.class, this::onNOVARecipeAdded);
 		recipeManager.whenRecipeRemoved(CraftingRecipe.class, this::onNOVARecipeRemoved);

--- a/src/main/java/nova/internal/core/tick/UpdateTicker.java
+++ b/src/main/java/nova/internal/core/tick/UpdateTicker.java
@@ -50,7 +50,7 @@ public class UpdateTicker {
 	private double deltaTime;
 
 	public UpdateTicker() {
-		last = System.currentTimeMillis();
+		last = System.nanoTime();
 	}
 
 	public void add(Updater ticker) {
@@ -82,9 +82,9 @@ public class UpdateTicker {
 			preEvents.clear();
 		}
 
-		long current = System.currentTimeMillis();
+		long current = System.nanoTime();
 		//The time in milliseconds between the last update and this one.
-		deltaTime = (current - last) / 1000d;
+		deltaTime = (current - last) / 1_000_000_000d;
 		synchronized (updaters) {
 			//TODO: Check the threshold
 			Stream<Updater> stream = updaters.size() > 1000 ? updaters.parallelStream() : updaters.stream();


### PR DESCRIPTION
As explained [here](https://javaantipatterns.wordpress.com/2012/03/15/measure-time-intervals-using-system-currenttimemillis/):

`System.currentTimeMillis()` returns the time of the system clock, which can also change backwards when the system time changes, it's also affected by leap seconds.

`System.nanoTime()` on the other hand returns the internal time of the Java Virtual Machine which does not depend on the system clock, so it's guaranteed that its value grows only from the past to the future.