### PR TITLE
Add !/.gitattributes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !/minecraft
 
 # github
+!/.gitattributes
 !/.gitignore
 !/README.md
 


### PR DESCRIPTION
This PR adds `!/.gitattributes` to the `.gitignore` file, so that it is included in commits.