### PR TITLE
Use the `instance()` method for all `NativeConverter` implementations

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ClientProxy.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ClientProxy.java
@@ -43,12 +43,12 @@ import nova.core.wrapper.mc.forge.v17.render.RenderUtility;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTile;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.forward.FWTileRenderer;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.backward.BWEntityFX;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.forward.FWEntity;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.forward.FWEntityFX;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.forward.FWEntityRenderer;
 import nova.core.wrapper.mc.forge.v17.wrapper.item.FWItem;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.io.IOException;
@@ -156,7 +156,7 @@ public class ClientProxy extends CommonProxy {
 		if (build instanceof BWEntityFX) {
 			EntityFX entityFX = ((BWEntityFX) build).createEntityFX();
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(entityFX);
-			return Game.natives().toNova(entityFX);
+			return EntityConverter.instance().toNova(entityFX);
 		} else {
 			FWEntityFX bwEntityFX = new FWEntityFX(world, factory);
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(bwEntityFX);
@@ -174,7 +174,7 @@ public class ClientProxy extends CommonProxy {
 			entityFX.posY = position.getY();
 			entityFX.posZ = position.getZ();
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(entityFX);
-			return Game.natives().toNova(entityFX);
+			return EntityConverter.instance().toNova(entityFX);
 		} else {
 			FWEntityFX bwEntityFX = new FWEntityFX(world, entity);
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(bwEntityFX);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/FMLEventHandler.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/FMLEventHandler.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v17.launcher;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import nova.core.event.PlayerEvent;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
 import nova.internal.core.Game;
 
 /**
@@ -32,12 +33,12 @@ import nova.internal.core.Game;
 public class FMLEventHandler {
 	@SubscribeEvent
 	public void playerJoin(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent evt) {
-		Game.events().publish(new PlayerEvent.Join(Game.natives().toNova(evt.player)));
+		Game.events().publish(new PlayerEvent.Join(EntityConverter.instance().toNova(evt.player)));
 	}
 
 	@SubscribeEvent
 	public void playerLeave(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent evt) {
-		Game.events().publish(new PlayerEvent.Leave(Game.natives().toNova(evt.player)));
+		Game.events().publish(new PlayerEvent.Leave(EntityConverter.instance().toNova(evt.player)));
 	}
 
 	@SubscribeEvent

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ForgeEventHandler.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ForgeEventHandler.java
@@ -28,6 +28,8 @@ import net.minecraftforge.oredict.OreDictionary;
 import nova.core.event.PlayerEvent;
 import nova.core.item.Item;
 import nova.core.item.ItemDictionary;
+import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.item.ItemConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -38,12 +40,12 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 public class ForgeEventHandler {
 	@SubscribeEvent
 	public void worldUnload(WorldEvent.Load evt) {
-		Game.events().publish(new nova.core.event.WorldEvent.Load(Game.natives().toNova(evt.world)));
+		Game.events().publish(new nova.core.event.WorldEvent.Load(WorldConverter.instance().toNova(evt.world)));
 	}
 
 	@SubscribeEvent
 	public void worldLoad(WorldEvent.Unload evt) {
-		Game.events().publish(new nova.core.event.WorldEvent.Unload(Game.natives().toNova(evt.world)));
+		Game.events().publish(new nova.core.event.WorldEvent.Unload(WorldConverter.instance().toNova(evt.world)));
 	}
 
 	@SubscribeEvent
@@ -58,20 +60,20 @@ public class ForgeEventHandler {
 
 	@SubscribeEvent
 	public void playerJoin(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent evt) {
-		Game.events().publish(new PlayerEvent.Join(Game.natives().toNova(evt.player)));
+		Game.events().publish(new PlayerEvent.Join(EntityConverter.instance().toNova(evt.player)));
 	}
 
 	@SubscribeEvent
 	public void playerLeave(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent evt) {
-		Game.events().publish(new PlayerEvent.Leave(Game.natives().toNova(evt.player)));
+		Game.events().publish(new PlayerEvent.Leave(EntityConverter.instance().toNova(evt.player)));
 	}
 
 	@SubscribeEvent
 	public void playerInteractEvent(PlayerInteractEvent event) {
 		nova.core.event.PlayerEvent.Interact evt = new nova.core.event.PlayerEvent.Interact(
-			Game.natives().toNova(event.world),
+			WorldConverter.instance().toNova(event.world),
 			new Vector3D(event.x, event.y, event.z),
-			Game.natives().toNova(event.entityPlayer),
+			EntityConverter.instance().toNova(event.entityPlayer),
 			nova.core.event.PlayerEvent.Interact.Action.values()[event.action.ordinal()]
 		);
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/MCRetentionManager.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/MCRetentionManager.java
@@ -30,6 +30,7 @@ import net.minecraftforge.event.world.WorldEvent;
 import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.registry.RetentionManager;
+import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
 import java.io.File;
@@ -59,13 +60,13 @@ public class MCRetentionManager extends RetentionManager {
 	public void save(String filename, Storable storable) {
 		Data saveMap = new Data();
 		storable.save(saveMap);
-		saveFile(filename, Game.natives().toNative(saveMap));
+		saveFile(filename, DataConverter.instance().toNative(saveMap));
 	}
 
 	@Override
 	public void load(String filename, Storable storable) {
 		NBTTagCompound nbt = loadFile(filename);
-		storable.load(Game.natives().toNova(nbt));
+		storable.load(DataConverter.instance().toNova(nbt));
 	}
 
 	/**

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/network/discriminator/NovaPacket.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/network/discriminator/NovaPacket.java
@@ -23,11 +23,11 @@ package nova.core.wrapper.mc.forge.v17.network.discriminator;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.entity.player.EntityPlayer;
-import nova.core.entity.Entity;
 import nova.core.entity.component.Player;
 import nova.core.network.handler.PacketHandler;
 import nova.core.wrapper.mc.forge.v17.network.MCPacket;
 import nova.core.wrapper.mc.forge.v17.network.netty.MCNetworkManager;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
 import nova.internal.core.Game;
 
 /**
@@ -65,7 +65,7 @@ public class NovaPacket extends PacketAbstract {
 			MCNetworkManager network = (MCNetworkManager) Game.network();
 			PacketHandler<?> packetHandler = network.getPacketType(data.readInt());
 			int subId = data.readInt();
-			MCPacket packet = new MCPacket(data.slice(), ((Entity) Game.natives().toNova(player)).components.get(Player.class));
+			MCPacket packet = new MCPacket(data.slice(), EntityConverter.instance().toNova(player).components.get(Player.class));
 			//Set the ID of the packet
 			packet.setID(subId);
 			packetHandler.read(packet);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverter.java
@@ -69,7 +69,7 @@ public class DirectionConverter implements NativeConverter<Direction, EnumFacing
 			case SOUTH: return EnumFacing.SOUTH;
 			case WEST:  return EnumFacing.WEST;
 			case EAST:  return EnumFacing.EAST;
-			default: return (EnumFacing) null;
+			default: return null;
 		}
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlock.java
@@ -33,7 +33,6 @@ import nova.core.block.component.BlockProperty;
 import nova.core.block.component.LightEmitter;
 import nova.core.component.misc.Collider;
 import nova.core.component.renderer.StaticRenderer;
-import nova.core.component.transform.BlockTransform;
 import nova.core.item.ItemFactory;
 import nova.core.render.model.CustomModel;
 import nova.core.retention.Data;
@@ -47,6 +46,7 @@ import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.cuboid.CuboidConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.item.ItemConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
@@ -113,7 +113,7 @@ public class BWBlock extends Block implements Storable {
 
 	@Override
 	public ItemFactory getItemFactory() {
-		return Game.natives().toNova(new ItemStack(Item.getItemFromBlock(mcBlock)));
+		return ItemConverter.instance().toNova(new ItemStack(Item.getItemFromBlock(mcBlock))).getFactory();
 	}
 
 	public int xi() {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlockTransform.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/backward/BWBlockTransform.java
@@ -25,7 +25,6 @@ import net.minecraft.world.IBlockAccess;
 import nova.core.component.transform.BlockTransform;
 import nova.core.world.World;
 import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.Optional;
@@ -61,8 +60,8 @@ public class BWBlockTransform extends BlockTransform {
 
 	@Override
 	public void setWorld(World world) {
-		net.minecraft.world.World oldWorld = Game.natives().toNative(this.world);
-		net.minecraft.world.World newWorld = Game.natives().toNative(world);
+		net.minecraft.world.World oldWorld = (net.minecraft.world.World) WorldConverter.instance().toNative(this.world);
+		net.minecraft.world.World newWorld = (net.minecraft.world.World) WorldConverter.instance().toNative(world);
 		Optional<TileEntity> tileEntity = Optional.ofNullable(oldWorld.getTileEntity((int) position.getX(), (int) position.getY(), (int) position.getZ()));
 		Optional<NBTTagCompound> nbt = Optional.empty();
 		if (tileEntity.isPresent()) {
@@ -82,7 +81,7 @@ public class BWBlockTransform extends BlockTransform {
 
 	@Override
 	public void setPosition(Vector3D position) {
-		net.minecraft.world.World world = Game.natives().toNative(this.world);
+		net.minecraft.world.World world = (net.minecraft.world.World) WorldConverter.instance().toNative(this.world);
 		Optional<TileEntity> tileEntity = Optional.ofNullable(world.getTileEntity((int) this.position.getX(), (int) this.position.getY(), (int) this.position.getZ()));
 		Optional<NBTTagCompound> nbt = Optional.empty();
 		if (tileEntity.isPresent()) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWBlock.java
@@ -47,7 +47,6 @@ import nova.core.block.component.BlockProperty;
 import nova.core.block.component.LightEmitter;
 import nova.core.component.Updater;
 import nova.core.component.misc.Collider;
-import nova.core.component.renderer.DynamicRenderer;
 import nova.core.component.renderer.Renderer;
 import nova.core.component.renderer.StaticRenderer;
 import nova.core.retention.Storable;
@@ -57,6 +56,10 @@ import nova.core.util.math.MathUtil;
 import nova.core.util.math.MatrixStack;
 import nova.core.util.shape.Cuboid;
 import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
+import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.cuboid.CuboidConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.entity.EntityConverter;
+import nova.core.wrapper.mc.forge.v17.wrapper.item.ItemConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.render.BWModel;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -149,7 +152,7 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 				e.printStackTrace();
 			}
 		}
-		return getBlockInstance((nova.core.world.World) Game.natives().toNova(access), position);
+		return getBlockInstance(WorldConverter.instance().toNova(access), position);
 
 	}
 
@@ -193,18 +196,18 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 		Block.DropEvent event = new Block.DropEvent(blockInstance);
 		blockInstance.events.publish(event);
 
-		return new ArrayList<>(
-			event.drops
-				.stream()
-				.map(item -> (ItemStack) Game.natives().toNative(item))
-				.collect(Collectors.toCollection(ArrayList::new))
-		);
+		return event.drops
+			.stream()
+			.map(ItemConverter.instance()::toNative)
+			.collect(Collectors.toCollection(ArrayList::new));
 	}
 
 	@Override
 	public boolean hasTileEntity(int metadata) {
 		// A block requires a TileEntity if it stores data or if it ticks.
-		return Storable.class.isAssignableFrom(blockClass) || Stateful.class.isAssignableFrom(blockClass) || Updater.class.isAssignableFrom(blockClass);
+		return Storable.class.isAssignableFrom(blockClass)
+			|| Stateful.class.isAssignableFrom(blockClass)
+			|| Updater.class.isAssignableFrom(blockClass);
 	}
 
 	@Override
@@ -261,7 +264,7 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 	@Override
 	public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean willHarvest) {
 		Block blockInstance = getBlockInstance(world, new Vector3D(x, y, z));
-		Block.RemoveEvent evt = new Block.RemoveEvent(Optional.of(Game.natives().toNova(player)));
+		Block.RemoveEvent evt = new Block.RemoveEvent(Optional.of(EntityConverter.instance().toNova(player)));
 		blockInstance.events.publish(evt);
 		if (evt.result) {
 			return super.removedByPlayer(world, player, x, y, z, willHarvest);
@@ -273,7 +276,7 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 	public void onBlockClicked(World world, int x, int y, int z, EntityPlayer player) {
 		Block blockInstance = getBlockInstance(world, new Vector3D(x, y, z));
 		MovingObjectPosition mop = player.rayTrace(10, 1);
-		Block.LeftClickEvent evt = new Block.LeftClickEvent(Game.natives().toNova(player), Direction.fromOrdinal(mop.sideHit), new Vector3D(mop.hitVec.xCoord, mop.hitVec.yCoord, mop.hitVec.zCoord));
+		Block.LeftClickEvent evt = new Block.LeftClickEvent(EntityConverter.instance().toNova(player), Direction.fromOrdinal(mop.sideHit), new Vector3D(mop.hitVec.xCoord, mop.hitVec.yCoord, mop.hitVec.zCoord));
 		blockInstance.events.publish(evt);
 	}
 
@@ -285,7 +288,7 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
 		Block blockInstance = getBlockInstance(world, new Vector3D(x, y, z));
-		Block.RightClickEvent evt = new Block.RightClickEvent(Game.natives().toNova(player), Direction.fromOrdinal(side), new Vector3D(hitX, hitY, hitZ));
+		Block.RightClickEvent evt = new Block.RightClickEvent(EntityConverter.instance().toNova(player), Direction.fromOrdinal(side), new Vector3D(hitX, hitY, hitZ));
 		blockInstance.events.publish(evt);
 		return evt.result;
 	}
@@ -293,7 +296,7 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 	@Override
 	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
 		Block blockInstance = getBlockInstance(world, new Vector3D(x, y, z));
-		blockInstance.components.getOp(Collider.class).ifPresent(collider -> blockInstance.events.publish(new Collider.CollideEvent(Game.natives().toNova(entity))));
+		blockInstance.components.getOp(Collider.class).ifPresent(collider -> blockInstance.events.publish(new Collider.CollideEvent(EntityConverter.instance().toNova(entity))));
 	}
 
 	@Override
@@ -312,24 +315,25 @@ public class FWBlock extends net.minecraft.block.Block implements ISimpleBlockRe
 
 		if (blockInstance.components.has(Collider.class)) {
 			Cuboid cuboid = blockInstance.components.get(Collider.class).boundingBox.get();
-			return Game.natives().toNative(cuboid.add(new Vector3D(x, y, z)));
+			return CuboidConverter.instance().toNative(cuboid.add(new Vector3D(x, y, z)));
 		}
 		return super.getSelectedBoundingBoxFromPool(world, x, y, z);
 	}
 
 	@Override
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB aabb, List list, Entity entity) {
 		Block blockInstance = getBlockInstance(world, new Vector3D(x, y, z));
 		blockInstance.components.getOp(Collider.class).ifPresent(
 			collider -> {
-				Set<Cuboid> boxes = collider.occlusionBoxes.apply(Optional.ofNullable(entity != null ? Game.natives().toNova(entity) : null));
+				Set<Cuboid> boxes = collider.occlusionBoxes.apply(Optional.ofNullable(entity != null ? EntityConverter.instance().toNova(entity) : null));
 
 				list.addAll(
 					boxes
 						.stream()
 						.map(c -> c.add(new Vector3D(x, y, z)))
-						.filter(c -> c.intersects((Cuboid) Game.natives().toNova(aabb)))
-						.map(cuboid -> Game.natives().toNative(cuboid))
+						.filter(c -> c.intersects(CuboidConverter.instance().toNova(aabb)))
+						.map(CuboidConverter.instance()::toNative)
 						.collect(Collectors.toList())
 				);
 			}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/EntityConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/EntityConverter.java
@@ -35,6 +35,8 @@ import nova.internal.core.Game;
 
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 public class EntityConverter implements NativeConverter<Entity, net.minecraft.entity.Entity>, ForgeLoadable {
 
 	public static EntityConverter instance() {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntity.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/FWEntity.java
@@ -34,6 +34,7 @@ import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.shape.Cuboid;
 import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
+import nova.core.wrapper.mc.forge.v17.wrapper.cuboid.CuboidConverter;
 import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
@@ -195,7 +196,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 		this.posZ = z;
 		//Reset the bounding box
 		if (getBoundingBox() != null) {
-			setBounds(Game.natives().toNova(getBoundingBox()));
+			setBounds(CuboidConverter.instance().toNova(getBoundingBox()));
 		}
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/MCEntityTransform.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/entity/forward/MCEntityTransform.java
@@ -27,6 +27,7 @@ import nova.core.util.UniqueIdentifiable;
 import nova.core.util.math.RotationUtil;
 import nova.core.util.math.Vector3DUtil;
 import nova.core.world.World;
+import nova.core.wrapper.mc.forge.v17.wrapper.block.world.WorldConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -48,7 +49,7 @@ public class MCEntityTransform extends EntityTransform implements UniqueIdentifi
 
 	@Override
 	public World world() {
-		return Game.natives().toNova(wrapper.worldObj);
+		return WorldConverter.instance().toNova(wrapper.worldObj);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/inventory/BWInventory.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/inventory/BWInventory.java
@@ -24,6 +24,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import nova.core.component.inventory.Inventory;
 import nova.core.item.Item;
+import nova.core.wrapper.mc.forge.v17.wrapper.item.ItemConverter;
 import nova.internal.core.Game;
 
 import java.util.Optional;
@@ -37,18 +38,12 @@ public class BWInventory implements Inventory {
 
 	@Override
 	public Optional<Item> get(int i) {
-		ItemStack stackInSlot = wrapped.getStackInSlot(i);
-
-		if (stackInSlot == null) {
-			return Optional.empty();
-		}
-
-		return Optional.of(Game.natives().toNova(stackInSlot));
+		return Optional.ofNullable(wrapped.getStackInSlot(i)).map(ItemConverter.instance()::toNova);
 	}
 
 	@Override
 	public boolean set(int i, Item item) {
-		wrapped.setInventorySlotContents(i, Game.natives().toNative(item));
+		wrapped.setInventorySlotContents(i, ItemConverter.instance().toNative(item));
 		return true;
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/BWItemFactory.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/BWItemFactory.java
@@ -26,6 +26,7 @@ import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.retention.Data;
 import nova.core.wrapper.mc.forge.v17.util.WrapperEvent;
+import nova.core.wrapper.mc.forge.v17.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
 /**
@@ -60,7 +61,7 @@ public class BWItemFactory extends ItemFactory {
 	@Override
 	public Item build(Data data) {
 		int meta = (Integer) data.getOrDefault("damage", this.meta);
-		NBTTagCompound nbtData = Game.natives().toNative(data);
+		NBTTagCompound nbtData = DataConverter.instance().toNative(data);
 		BWItem bwItem = new BWItem(item, meta, nbtData);
 		bwItem.components.add(new FactoryProvider(this));
 		WrapperEvent.BWItemCreate event = new WrapperEvent.BWItemCreate(bwItem, item);
@@ -76,7 +77,7 @@ public class BWItemFactory extends ItemFactory {
 
 		BWItem mcItem = (BWItem) item;
 
-		Data result = mcItem.getTag() != null ? Game.natives().toNova(mcItem.getTag()) : new Data();
+		Data result = mcItem.getTag() != null ? DataConverter.instance().toNova(mcItem.getTag()) : new Data();
 		if (result == null) {
 			result = new Data();
 		}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
@@ -53,14 +53,15 @@ public interface ItemWrapperMethods extends IItemRenderer {
 
 	ItemFactory getItemFactory();
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	default void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		item.setCount(itemStack.stackSize).events.publish(new Item.TooltipEvent(Optional.of(new BWEntity(player)), list));
 		getItemFactory().save(item);
 	}
 
 	default boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		Item.UseEvent event = new Item.UseEvent(new BWEntity(player), new Vector3D(x, y, z), Direction.fromOrdinal(side), new Vector3D(hitX, hitY, hitZ));
 		item.events.publish(event);
 		ItemConverter.instance().updateMCItemStack(itemStack, item);
@@ -68,7 +69,7 @@ public interface ItemWrapperMethods extends IItemRenderer {
 	}
 
 	default ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		item.events.publish(new Item.RightClickEvent(new BWEntity(player)));
 		return ItemConverter.instance().updateMCItemStack(itemStack, item);
 	}
@@ -93,7 +94,7 @@ public interface ItemWrapperMethods extends IItemRenderer {
 
 	@Override
 	default void renderItem(IItemRenderer.ItemRenderType type, ItemStack itemStack, Object... data) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		if (item.components.has(Renderer.class)) {
 			GL11.glPushAttrib(GL_TEXTURE_BIT);
 			GL11.glEnable(GL12.GL_RESCALE_NORMAL);
@@ -111,7 +112,8 @@ public interface ItemWrapperMethods extends IItemRenderer {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	default int getColorFromItemStack(ItemStack itemStack, int p_82790_2_) {
-		return ((Item) Game.natives().toNova(itemStack)).colorMultiplier().argb();
+		return ItemConverter.instance().toNova(itemStack).colorMultiplier().argb();
 	}
 }

--- a/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverterTest.java
+++ b/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverterTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static nova.testutils.NovaAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Used to test {@link DirectionConverter}.
@@ -41,6 +40,12 @@ public class DirectionConverterTest {
 	@Before
 	public void setUp() {
 		converter = new DirectionConverter();
+	}
+
+	@Test
+	public void testClasses() {
+		assertThat(converter.getNovaSide()).isEqualTo(Direction.class);
+		assertThat(converter.getNativeSide()).isEqualTo(EnumFacing.class);
 	}
 
 	@Test

--- a/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/assets/AssetConverterTest.java
+++ b/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/assets/AssetConverterTest.java
@@ -21,11 +21,15 @@
 package nova.core.wrapper.mc.forge.v17.wrapper.assets;
 
 import net.minecraft.util.ResourceLocation;
+import nova.core.render.texture.BlockTexture;
+import nova.core.render.texture.EntityTexture;
+import nova.core.render.texture.ItemTexture;
+import nova.core.render.texture.Texture;
 import nova.core.util.Asset;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static nova.testutils.NovaAssertions.assertThat;
 
 /**
  * Used to test {@link AssetConverter}.
@@ -42,11 +46,20 @@ public class AssetConverterTest {
 	}
 
 	@Test
+	public void testClasses() {
+		assertThat(converter.getNovaSide()).isEqualTo(Asset.class);
+		assertThat(converter.getNativeSide()).isEqualTo(ResourceLocation.class);
+	}
+
+	@Test
 	public void testToNova() {
 		assertThat(converter.toNova(new ResourceLocation("nova", "stuff"))).isEqualTo(new Asset("nova", "stuff"));
 		assertThat(converter.toNova(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Asset("nova", "otherStuff"));
 		assertThat(converter.toNova(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Asset("nova", "otherstuff"));
 		// NOVA's Assets are entirely case-insensitive
+		assertThat(converter.toNovaTexture(new ResourceLocation("nova", "stuff"))).isEqualTo(new Texture("nova", "stuff"));
+		assertThat(converter.toNovaTexture(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Texture("nova", "otherStuff"));
+		assertThat(converter.toNovaTexture(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Texture("nova", "otherstuff"));
 	}
 
 	@Test
@@ -55,5 +68,14 @@ public class AssetConverterTest {
 		assertThat(converter.toNative(new Asset("nova", "otherStuff"))).isNotEqualTo(new ResourceLocation("nova:otherstuff"));
 		assertThat(converter.toNative(new Asset("nova", "otherStuff"))).isEqualTo(new ResourceLocation("nova:otherStuff"));
 		// 1.8 ResourceLocation is partially case sensitive. 1.11 ResourceLocation is all lowercase.
+		assertThat(converter.toNativeTexture(new Asset("nova", "stuff"))).isEqualTo(new ResourceLocation("nova", "stuff"));
+		assertThat(converter.toNativeTexture(new Texture("nova", "otherStuff.png"))).isEqualTo(new ResourceLocation("nova:otherStuff"));
+		assertThat(converter.toNativeTexture(new Texture("nova", "otherStuff.png"), true)).isEqualTo(new ResourceLocation("nova:otherStuff.png"));
+		assertThat(converter.toNativeTexture(new BlockTexture("nova", "otherStuff.png"))).isEqualTo(new ResourceLocation("nova:otherStuff"));
+		assertThat(converter.toNativeTexture(new BlockTexture("nova", "otherStuff.png"), true)).isEqualTo(new ResourceLocation("nova:otherStuff.png"));
+		assertThat(converter.toNativeTexture(new ItemTexture("nova", "otherStuff.png"))).isEqualTo(new ResourceLocation("nova:otherStuff"));
+		assertThat(converter.toNativeTexture(new ItemTexture("nova", "otherStuff.png"), true)).isEqualTo(new ResourceLocation("nova:otherStuff.png"));
+		assertThat(converter.toNativeTexture(new EntityTexture("nova", "otherStuff.png"))).isEqualTo(new ResourceLocation("nova:../entities/otherStuff"));
+		assertThat(converter.toNativeTexture(new EntityTexture("nova", "otherStuff.png"), true)).isEqualTo(new ResourceLocation("nova:../entities/otherStuff.png"));
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ClientProxy.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ClientProxy.java
@@ -47,12 +47,12 @@ import nova.core.wrapper.mc.forge.v18.render.RenderUtility;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTile;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWTileRenderer;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.backward.BWEntityFX;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.FWEntity;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.FWEntityFX;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.FWEntityRenderer;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.FWItem;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.io.IOException;
@@ -180,7 +180,7 @@ public class ClientProxy extends CommonProxy {
 		if (build instanceof BWEntityFX) {
 			EntityFX entityFX = ((BWEntityFX) build).createEntityFX(world);
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(entityFX);
-			return Game.natives().toNova(entityFX);
+			return EntityConverter.instance().toNova(entityFX);
 		} else {
 			FWEntityFX bwEntityFX = new FWEntityFX(world, factory);
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(bwEntityFX);
@@ -198,7 +198,7 @@ public class ClientProxy extends CommonProxy {
 			entityFX.posY = position.getY();
 			entityFX.posZ = position.getZ();
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(entityFX);
-			return Game.natives().toNova(entityFX);
+			return EntityConverter.instance().toNova(entityFX);
 		} else {
 			FWEntityFX bwEntityFX = new FWEntityFX(world, entity);
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(bwEntityFX);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/FMLEventHandler.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/FMLEventHandler.java
@@ -23,6 +23,7 @@ package nova.core.wrapper.mc.forge.v18.launcher;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import nova.core.event.PlayerEvent;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
 import nova.internal.core.Game;
 
 /**
@@ -32,12 +33,12 @@ import nova.internal.core.Game;
 public class FMLEventHandler {
 	@SubscribeEvent
 	public void playerJoin(net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent evt) {
-		Game.events().publish(new PlayerEvent.Join(Game.natives().toNova(evt.player)));
+		Game.events().publish(new PlayerEvent.Join(EntityConverter.instance().toNova(evt.player)));
 	}
 
 	@SubscribeEvent
 	public void playerLeave(net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent evt) {
-		Game.events().publish(new PlayerEvent.Leave(Game.natives().toNova(evt.player)));
+		Game.events().publish(new PlayerEvent.Leave(EntityConverter.instance().toNova(evt.player)));
 	}
 
 	@SubscribeEvent

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ForgeEventHandler.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ForgeEventHandler.java
@@ -27,6 +27,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.oredict.OreDictionary;
 import nova.core.item.Item;
 import nova.core.item.ItemDictionary;
+import nova.core.wrapper.mc.forge.v18.wrapper.VectorConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.block.world.WorldConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -38,12 +41,12 @@ public class ForgeEventHandler {
 
 	@SubscribeEvent
 	public void worldUnload(WorldEvent.Load evt) {
-		Game.events().publish(new nova.core.event.WorldEvent.Load(Game.natives().toNova(evt.world)));
+		Game.events().publish(new nova.core.event.WorldEvent.Load(WorldConverter.instance().toNova(evt.world)));
 	}
 
 	@SubscribeEvent
 	public void worldLoad(WorldEvent.Unload evt) {
-		Game.events().publish(new nova.core.event.WorldEvent.Unload(Game.natives().toNova(evt.world)));
+		Game.events().publish(new nova.core.event.WorldEvent.Unload(WorldConverter.instance().toNova(evt.world)));
 	}
 
 	@SubscribeEvent
@@ -60,9 +63,9 @@ public class ForgeEventHandler {
 	public void playerInteractEvent(PlayerInteractEvent event) {
 		if (event.world != null && event.pos != null) {
 			nova.core.event.PlayerEvent.Interact evt = new nova.core.event.PlayerEvent.Interact(
-				Game.natives().toNova(event.world),
-				new Vector3D(event.pos.getX(), event.pos.getY(), event.pos.getZ()),
-				Game.natives().toNova(event.entityPlayer),
+				WorldConverter.instance().toNova(event.world),
+				VectorConverter.instance().toNova(event.pos),
+				EntityConverter.instance().toNova(event.entityPlayer),
 				nova.core.event.PlayerEvent.Interact.Action.values()[event.action.ordinal()]
 			);
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/manager/MCRetentionManager.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/manager/MCRetentionManager.java
@@ -30,6 +30,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.registry.RetentionManager;
+import nova.core.wrapper.mc.forge.v18.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
 import java.io.File;
@@ -59,13 +60,13 @@ public class MCRetentionManager extends RetentionManager {
 	public void save(String filename, Storable storable) {
 		Data saveMap = new Data();
 		storable.save(saveMap);
-		saveFile(filename, Game.natives().toNative(saveMap));
+		saveFile(filename, DataConverter.instance().toNative(saveMap));
 	}
 
 	@Override
 	public void load(String filename, Storable storable) {
 		NBTTagCompound nbt = loadFile(filename);
-		storable.load(Game.natives().toNova(nbt));
+		storable.load(DataConverter.instance().toNova(nbt));
 	}
 
 	/**

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/network/discriminator/NovaPacket.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/network/discriminator/NovaPacket.java
@@ -28,6 +28,7 @@ import nova.core.entity.component.Player;
 import nova.core.network.handler.PacketHandler;
 import nova.core.wrapper.mc.forge.v18.network.MCPacket;
 import nova.core.wrapper.mc.forge.v18.network.netty.MCNetworkManager;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
 import nova.internal.core.Game;
 
 /**
@@ -65,7 +66,7 @@ public class NovaPacket extends PacketAbstract {
 			MCNetworkManager network = (MCNetworkManager) Game.network();
 			PacketHandler<?> packetHandler = network.getPacketType(data.readInt());
 			int subId = data.readInt();
-			MCPacket packet = new MCPacket(data.slice(), ((Entity) Game.natives().toNova(player)).components.get(Player.class));
+			MCPacket packet = new MCPacket(data.slice(), EntityConverter.instance().toNova(player).components.get(Player.class));
 			//Set the ID of the packet
 			packet.setID(subId);
 			packetHandler.read(packet);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/VectorConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/VectorConverter.java
@@ -21,6 +21,8 @@
 package nova.core.wrapper.mc.forge.v18.wrapper;
 
 import net.minecraft.util.BlockPos;
+import net.minecraft.util.Vec3;
+import net.minecraft.util.Vec3i;
 import nova.core.nativewrapper.NativeConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -43,6 +45,14 @@ public class VectorConverter implements NativeConverter<Vector3D, BlockPos> {
 
 	@Override
 	public Vector3D toNova(BlockPos pos) {
+		return toNova((Vec3i) pos);
+	}
+
+	public Vector3D toNova(Vec3 pos) {
+		return new Vector3D(pos.xCoord, pos.yCoord, pos.zCoord);
+	}
+
+	public Vector3D toNova(Vec3i pos) {
 		return new Vector3D(pos.getX(), pos.getY(), pos.getZ());
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlock.java
@@ -50,6 +50,7 @@ import nova.core.wrapper.mc.forge.v18.wrapper.block.world.WorldConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.cuboid.CuboidConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.data.DataConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.render.backward.BWBakedModel;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -137,7 +138,7 @@ public class BWBlock extends Block implements Storable {
 
 	@Override
 	public ItemFactory getItemFactory() {
-		return Game.natives().toNova(new ItemStack(Item.getItemFromBlock(mcBlock)));
+		return ItemConverter.instance().toNova(new ItemStack(Item.getItemFromBlock(mcBlock))).getFactory();
 	}
 
 	public net.minecraft.block.Block block() {
@@ -174,7 +175,7 @@ public class BWBlock extends Block implements Storable {
 			return false;
 		}
 
-		if (mcBlock == Blocks.vine || mcBlock == Blocks.tallgrass || mcBlock == Blocks.deadbush || mcBlock.isReplaceable(Game.natives().toNative(world()), new BlockPos(x(), y(), z()))) {
+		if (mcBlock == Blocks.vine || mcBlock == Blocks.tallgrass || mcBlock == Blocks.deadbush || mcBlock.isReplaceable((net.minecraft.world.World) WorldConverter.instance().toNative(world()), new BlockPos(x(), y(), z()))) {
 			return false;
 		}
 		return super.shouldDisplacePlacement();

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlockTransform.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/backward/BWBlockTransform.java
@@ -23,12 +23,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.chunk.Chunk;
 import nova.core.component.transform.BlockTransform;
 import nova.core.world.World;
 import nova.core.wrapper.mc.forge.v18.wrapper.VectorConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.world.WorldConverter;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.Optional;
@@ -69,8 +67,8 @@ public class BWBlockTransform extends BlockTransform {
 	@Override
 	public void setWorld(World world) {
 		BlockPos pos = blockPos();
-		net.minecraft.world.World oldWorld = Game.natives().toNative(this.world);
-		net.minecraft.world.World newWorld = Game.natives().toNative(world);
+		net.minecraft.world.World oldWorld = (net.minecraft.world.World) WorldConverter.instance().toNative(this.world);
+		net.minecraft.world.World newWorld = (net.minecraft.world.World) WorldConverter.instance().toNative(world);
 		Optional<TileEntity> tileEntity = Optional.ofNullable(oldWorld.getTileEntity(pos));
 		Optional<NBTTagCompound> nbt = Optional.empty();
 		if (tileEntity.isPresent()) {
@@ -92,7 +90,7 @@ public class BWBlockTransform extends BlockTransform {
 	public void setPosition(Vector3D position) {
 		BlockPos oldPos = blockPos();
 		BlockPos newPos = VectorConverter.instance().toNative(position);
-		net.minecraft.world.World world = Game.natives().toNative(this.world);
+		net.minecraft.world.World world = (net.minecraft.world.World) WorldConverter.instance().toNative(this.world);
 		Optional<TileEntity> tileEntity = Optional.ofNullable(blockAccess().getTileEntity(oldPos));
 		Optional<NBTTagCompound> nbt = Optional.empty();
 		if (tileEntity.isPresent()) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/BWWorld.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/BWWorld.java
@@ -35,14 +35,19 @@ import nova.core.sound.Sound;
 import nova.core.util.shape.Cuboid;
 import nova.core.world.World;
 import nova.core.wrapper.mc.forge.v18.launcher.NovaMinecraft;
+import nova.core.wrapper.mc.forge.v18.wrapper.VectorConverter;
+import nova.core.wrapper.mc.forge.v18.wrapper.block.BlockConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.backward.BWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.FWBlock;
 import nova.core.wrapper.mc.forge.v18.wrapper.block.forward.MCBlockTransform;
+import nova.core.wrapper.mc.forge.v18.wrapper.entity.EntityConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.FWEntity;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.forward.MCEntityTransform;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -96,9 +101,8 @@ public class BWWorld extends World {
 
 	@Override
 	public boolean setBlock(Vector3D position, BlockFactory blockFactory) {
-		//TODO: Do not call blockFactory.build()
-		net.minecraft.block.Block mcBlock = Game.natives().toNative(blockFactory.build());
-		BlockPos pos = new BlockPos((int) position.getX(), (int) position.getY(), (int) position.getZ());
+		net.minecraft.block.Block mcBlock = BlockConverter.instance().toNative(blockFactory);
+		BlockPos pos = VectorConverter.instance().toNative(position);
 		net.minecraft.block.Block actualBlock = mcBlock != null ? mcBlock : Blocks.air;
 		IBlockState defaultState = actualBlock.getDefaultState();
 		IBlockState extendedState = actualBlock.getExtendedState(defaultState, world(), pos);
@@ -124,6 +128,7 @@ public class BWWorld extends World {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Entity addClientEntity(Entity entity) {
 		return NovaMinecraft.proxy.spawnParticle(world(), entity);
 	}
@@ -136,24 +141,24 @@ public class BWWorld extends World {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Set<Entity> getEntities(Cuboid bound) {
-		return (Set) world()
-			.getEntitiesWithinAABB(net.minecraft.entity.Entity.class, AxisAlignedBB.fromBounds(bound.min.getX(), bound.min.getY(), bound.min.getZ(), bound.max.getX(), bound.max.getY(), bound.max.getZ()))
+		return ((List<net.minecraft.entity.Entity>) world().getEntitiesWithinAABB(net.minecraft.entity.Entity.class, AxisAlignedBB.fromBounds(bound.min.getX(), bound.min.getY(), bound.min.getZ(), bound.max.getX(), bound.max.getY(), bound.max.getZ())))
 			.stream()
-			.map(mcEnt -> Game.natives().getNative(Entity.class, net.minecraft.entity.Entity.class).toNova((net.minecraft.entity.Entity) mcEnt))
+			.map(EntityConverter.instance()::toNova)
 			.collect(Collectors.toSet());
 	}
 
 	@Override
 	public Entity addEntity(Vector3D position, Item item) {
-		EntityItem entityItem = new EntityItem(world(), position.getX(), position.getY(), position.getZ(), Game.natives().toNative(item));
+		EntityItem entityItem = new EntityItem(world(), position.getX(), position.getY(), position.getZ(), ItemConverter.instance().toNative(item));
 		world().spawnEntityInWorld(entityItem);
-		return Game.natives().toNova(entityItem);
+		return EntityConverter.instance().toNova(entityItem);
 	}
 
 	@Override
 	public Optional<Entity> getEntity(String uniqueID) {
-		return Optional.ofNullable(Game.natives().toNova(world().getEntityByID(Integer.parseInt(uniqueID))));
+		return Optional.ofNullable(world().getEntityByID(Integer.parseInt(uniqueID))).map(EntityConverter.instance()::toNova);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntity.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/FWEntity.java
@@ -34,6 +34,7 @@ import nova.core.retention.Data;
 import nova.core.retention.Storable;
 import nova.core.util.shape.Cuboid;
 import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
+import nova.core.wrapper.mc.forge.v18.wrapper.cuboid.CuboidConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
@@ -196,7 +197,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 		this.posZ = z;
 		//Reset the bounding box
 		if (getBoundingBox() != null) {
-			setBounds(Game.natives().toNova(getBoundingBox()));
+			setBounds(CuboidConverter.instance().toNova(getBoundingBox()));
 		}
 	}
 
@@ -207,7 +208,7 @@ public class FWEntity extends net.minecraft.entity.Entity implements IEntityAddi
 	public void setBounds(Cuboid bounds) {
 		//TODO: Fix moveEntity auto-centering
 		if (transform != null) {
-			setEntityBoundingBox(Game.natives().toNative(bounds.add(transform.position())));
+			setEntityBoundingBox(CuboidConverter.instance().toNative(bounds.add(transform.position())));
 		}
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/MCEntityTransform.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/entity/forward/MCEntityTransform.java
@@ -27,7 +27,7 @@ import nova.core.util.UniqueIdentifiable;
 import nova.core.util.math.RotationUtil;
 import nova.core.util.math.Vector3DUtil;
 import nova.core.world.World;
-import nova.internal.core.Game;
+import nova.core.wrapper.mc.forge.v18.wrapper.block.world.WorldConverter;
 import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
@@ -48,7 +48,7 @@ public class MCEntityTransform extends EntityTransform implements UniqueIdentifi
 
 	@Override
 	public World world() {
-		return Game.natives().toNova(wrapper.worldObj);
+		return WorldConverter.instance().toNova(wrapper.worldObj);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/inventory/BWInventory.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/inventory/BWInventory.java
@@ -24,6 +24,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import nova.core.component.inventory.Inventory;
 import nova.core.item.Item;
+import nova.core.wrapper.mc.forge.v18.wrapper.item.ItemConverter;
 import nova.internal.core.Game;
 
 import java.util.Optional;
@@ -37,18 +38,12 @@ public class BWInventory implements Inventory {
 
 	@Override
 	public Optional<Item> get(int i) {
-		ItemStack stackInSlot = wrapped.getStackInSlot(i);
-
-		if (stackInSlot == null) {
-			return Optional.empty();
-		}
-
-		return Optional.of(Game.natives().toNova(stackInSlot));
+		return Optional.ofNullable(wrapped.getStackInSlot(i)).map(ItemConverter.instance()::toNova);
 	}
 
 	@Override
 	public boolean set(int i, Item item) {
-		wrapped.setInventorySlotContents(i, Game.natives().toNative(item));
+		wrapped.setInventorySlotContents(i, ItemConverter.instance().toNative(item));
 		return true;
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/BWItemFactory.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/BWItemFactory.java
@@ -26,6 +26,7 @@ import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.retention.Data;
 import nova.core.wrapper.mc.forge.v18.util.WrapperEvent;
+import nova.core.wrapper.mc.forge.v18.wrapper.data.DataConverter;
 import nova.internal.core.Game;
 
 /**
@@ -60,7 +61,7 @@ public class BWItemFactory extends ItemFactory {
 	@Override
 	public Item build(Data data) {
 		int meta = (Integer) data.getOrDefault("damage", this.meta);
-		NBTTagCompound nbtData = Game.natives().toNative(data);
+		NBTTagCompound nbtData = DataConverter.instance().toNative(data);
 		BWItem bwItem = new BWItem(item, meta, nbtData);
 		bwItem.components.add(new FactoryProvider(this));
 		WrapperEvent.BWItemCreate event = new WrapperEvent.BWItemCreate(bwItem, item);
@@ -76,7 +77,7 @@ public class BWItemFactory extends ItemFactory {
 
 		BWItem mcItem = (BWItem) item;
 
-		Data result = mcItem.getTag() != null ? Game.natives().toNova(mcItem.getTag()) : new Data();
+		Data result = mcItem.getTag() != null ? DataConverter.instance().toNova(mcItem.getTag()) : new Data();
 		if (result == null) {
 			result = new Data();
 		}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemWrapperMethods.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemWrapperMethods.java
@@ -41,14 +41,15 @@ public interface ItemWrapperMethods {
 
 	ItemFactory getItemFactory();
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	default void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		item.setCount(itemStack.stackSize).events.publish(new Item.TooltipEvent(Optional.of(new BWEntity(player)), list));
 		getItemFactory().save(item);
 	}
 
 	default boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		Item.UseEvent event = new Item.UseEvent(new BWEntity(player), new Vector3D(x, y, z), Direction.fromOrdinal(side), new Vector3D(hitX, hitY, hitZ));
 		item.events.publish(event);
 		ItemConverter.instance().updateMCItemStack(itemStack, item);
@@ -56,12 +57,13 @@ public interface ItemWrapperMethods {
 	}
 
 	default ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
-		Item item = Game.natives().toNova(itemStack);
+		Item item = ItemConverter.instance().toNova(itemStack);
 		item.events.publish(new Item.RightClickEvent(new BWEntity(player)));
 		return ItemConverter.instance().updateMCItemStack(itemStack, item);
 	}
 
+	@SuppressWarnings("deprecation")
 	default int getColorFromItemStack(ItemStack itemStack, int p_82790_2_) {
-		return ((Item) Game.natives().toNova(itemStack)).colorMultiplier().argb();
+		return ItemConverter.instance().toNova(itemStack).colorMultiplier().argb();
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/backward/BWBakedModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/backward/BWBakedModel.java
@@ -37,8 +37,8 @@ import nova.core.util.Direction;
 import nova.core.util.math.MatrixStack;
 import nova.core.util.math.TransformUtil;
 import nova.core.util.math.Vector3DUtil;
+import nova.core.wrapper.mc.forge.v18.wrapper.DirectionConverter;
 import nova.core.wrapper.mc.forge.v18.wrapper.assets.AssetConverter;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.math3.geometry.euclidean.twod.Vector2D;
 import org.apache.commons.math3.linear.LUDecomposition;
@@ -48,7 +48,6 @@ import org.apache.commons.math3.linear.RealMatrix;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -124,7 +123,7 @@ public class BWBakedModel extends MeshModel {
 	public List<BakedQuad> getFaceQuads(Direction direction) {
 		if (direction == Direction.UNKNOWN)
 			return getGeneralQuads();
-		return getFaceQuads((EnumFacing) Game.natives().toNative(direction));
+		return getFaceQuads(DirectionConverter.instance().toNative(direction));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverterTest.java
+++ b/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/DirectionConverterTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static nova.testutils.NovaAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Used to test {@link DirectionConverter}.
@@ -40,6 +39,12 @@ public class DirectionConverterTest {
 	@Before
 	public void setUp() {
 		converter = new DirectionConverter();
+	}
+
+	@Test
+	public void testClasses() {
+		assertThat(converter.getNovaSide()).isEqualTo(Direction.class);
+		assertThat(converter.getNativeSide()).isEqualTo(EnumFacing.class);
 	}
 
 	@Test

--- a/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/VectorConverterTest.java
+++ b/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/VectorConverterTest.java
@@ -21,6 +21,7 @@
 package nova.core.wrapper.mc.forge.v18.wrapper;
 
 import net.minecraft.util.BlockPos;
+import net.minecraft.util.Vec3;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,11 +43,22 @@ public class VectorConverterTest {
 	}
 
 	@Test
+	public void testClasses() {
+		assertThat(converter.getNovaSide()).isEqualTo(Vector3D.class);
+		assertThat(converter.getNativeSide()).isEqualTo(BlockPos.class);
+	}
+
+	@Test
 	public void testToNova() {
 		for (int x = -1; x <= 1; x++)
 			for (int y = -1; y <= 1; y++)
 				for (int z = -1; z <= 1; z++)
 					assertThat(converter.toNova(new BlockPos(x, y, z))).isEqualTo(new Vector3D(x, y, z));
+
+		for (int x = -1; x <= 1; x++)
+			for (int y = -1; y <= 1; y++)
+				for (int z = -1; z <= 1; z++)
+					assertThat(converter.toNova(new Vec3(x, y, z))).isEqualTo(new Vector3D(x, y, z));
 	}
 
 	@Test

--- a/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/assets/AssetConverterTest.java
+++ b/minecraft/1.8/src/test/java/nova/core/wrapper/mc/forge/v18/wrapper/assets/AssetConverterTest.java
@@ -21,10 +21,12 @@
 package nova.core.wrapper.mc.forge.v18.wrapper.assets;
 
 import net.minecraft.util.ResourceLocation;
+import nova.core.render.texture.Texture;
 import nova.core.util.Asset;
 import org.junit.Before;
 import org.junit.Test;
 
+import static nova.testutils.NovaAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -42,11 +44,20 @@ public class AssetConverterTest {
 	}
 
 	@Test
+	public void testClasses() {
+		assertThat(converter.getNovaSide()).isEqualTo(Asset.class);
+		assertThat(converter.getNativeSide()).isEqualTo(ResourceLocation.class);
+	}
+
+	@Test
 	public void testToNova() {
 		assertThat(converter.toNova(new ResourceLocation("nova", "stuff"))).isEqualTo(new Asset("nova", "stuff"));
 		assertThat(converter.toNova(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Asset("nova", "otherStuff"));
 		assertThat(converter.toNova(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Asset("nova", "otherstuff"));
 		// NOVA's Assets are entirely case-insensitive
+		assertThat(converter.toNovaTexture(new ResourceLocation("nova", "stuff"))).isEqualTo(new Texture("nova", "stuff"));
+		assertThat(converter.toNovaTexture(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Texture("nova", "otherStuff"));
+		assertThat(converter.toNovaTexture(new ResourceLocation("nova:otherStuff"))).isEqualTo(new Texture("nova", "otherstuff"));
 	}
 
 	@Test
@@ -55,5 +66,8 @@ public class AssetConverterTest {
 		assertThat(converter.toNative(new Asset("nova", "otherStuff"))).isNotEqualTo(new ResourceLocation("nova:otherstuff"));
 		assertThat(converter.toNative(new Asset("nova", "otherStuff"))).isEqualTo(new ResourceLocation("nova:otherStuff"));
 		// 1.8 ResourceLocation is partially case sensitive. 1.11 ResourceLocation is all lowercase.
+		assertThat(converter.toNativeTexture(new Asset("nova", "stuff"))).isEqualTo(new ResourceLocation("nova", "stuff"));
+		assertThat(converter.toNativeTexture(new Texture("nova", "otherStuff.png"))).isEqualTo(new ResourceLocation("nova:otherStuff"));
+		assertThat(converter.toNativeTexture(new Texture("nova", "otherStuff.png"), true)).isEqualTo(new ResourceLocation("nova:otherStuff.png"));
 	}
 }

--- a/src/main/java/nova/core/nativewrapper/NativeConverter.java
+++ b/src/main/java/nova/core/nativewrapper/NativeConverter.java
@@ -26,13 +26,38 @@ package nova.core.nativewrapper;
  * Implementing a Loadable on a NativeConverter will allow it to handle loading events.
  *
  * @author TheSandromatic, Calclavia
+ * @param <NOVA> The NOVA implementation class.
+ * @param <NATIVE> The game implementation class.
  */
 public interface NativeConverter<NOVA, NATIVE> {
+
+	/**
+	 * Get the class of the NOVA implementation.
+	 *
+	 * @return The class of the NOVA implementation.
+	 */
 	Class<NOVA> getNovaSide();
 
+	/**
+	 * Get the class of the game implementation.
+	 *
+	 * @return The class of the game implementation.
+	 */
 	Class<NATIVE> getNativeSide();
 
+	/**
+	 * Convert a game implementation object to the NOVA equivalent.
+	 *
+	 * @param nativeObj A game implementation object.
+	 * @return The NOVA equivalent object.
+	 */
 	NOVA toNova(NATIVE nativeObj);
 
+	/**
+	 * Convert a NOVA implementation object to the game equivalent.
+	 *
+	 * @param novaObj A NOVA implementation object.
+	 * @return The game equivalent object.
+	 */
 	NATIVE toNative(NOVA novaObj);
 }

--- a/src/main/java/nova/core/nativewrapper/NativeManager.java
+++ b/src/main/java/nova/core/nativewrapper/NativeManager.java
@@ -16,7 +16,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
- */package nova.core.nativewrapper;
+ */
+
+package nova.core.nativewrapper;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -49,8 +51,10 @@ public class NativeManager {
 
 	/**
 	 * Registers a component to a native interface.
-	 * @param component A component. Must extend INTERFACE.
-	 * @param nativeInterface the class of the INTERFACE.
+	 *
+	 * @param <INTERFACE> The interface of the component.
+	 * @param component A component. Must extend {@code INTERFACE}.
+	 * @param nativeInterface the class of the {@code INTERFACE}.
 	 */
 	public <INTERFACE> void registerComponentToInterface(Class<? extends INTERFACE> component, Class<INTERFACE> nativeInterface) {
 		novaComponentToNativeInterface.put(component, nativeInterface);
@@ -107,6 +111,9 @@ public class NativeManager {
 
 	/**
 	 * Converts a native object to a nova object. This method has autocast, is DANGEROUS and may crash.
+	 *
+	 * @param nativeObject A game implementation object.
+	 * @return The NOVA equivalent object.
 	 */
 	public <T> T toNova(Object nativeObject) {
 		Objects.requireNonNull(nativeObject);
@@ -120,6 +127,9 @@ public class NativeManager {
 
 	/**
 	 * Converts a nova object to a native object. This method has autocast, is DANGEROUS and may crash.
+	 *
+	 * @param novaObject A NOVA implementation object.
+	 * @return The game equivalent object.
 	 */
 	public <T> T toNative(Object novaObject) {
 		Objects.requireNonNull(novaObject);
@@ -136,6 +146,8 @@ public class NativeManager {
 	}
 
 	public static class NativeException extends NovaException {
+		private static final long serialVersionUID = 1L;
+
 		public NativeException() {
 			super();
 		}


### PR DESCRIPTION
This makes it so that when I make a change to a `NativeConverter` implementation, I don’t forget to update any usage of said `NativeConverter` implementation and get a `nova.core.nativewrapper.NativeManager.NativeException: Cannot find native converter for: <class>` or a `ClassCastException`.