### PR TITLE
Update Typetools to 0.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 	api 'org.slf4j:slf4j-api:1.7.10'
 	api 'org.apache.commons:commons-math3:3.5'
 	api 'javax.json:javax.json-api:1.0'
-	implementation 'net.jodah:typetools:0.4.9'
+	implementation 'net.jodah:typetools:0.5.0'
 
 	runtimeOnly 'org.glassfish:javax.json:1.0.4'
 	testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.10'


### PR DESCRIPTION
This is necessary to allow running NOVA on Java 9.