### PR TITLE
Make used ForgeGradle version independently configurable

### DIFF
--- a/minecraft/1.7/gradle.properties
+++ b/minecraft/1.7/gradle.properties
@@ -2,6 +2,7 @@ group = nova.core
 
 minecraft.version = 1.7.10
 forge.version = 10.13.4.1448-1.7.10
+forgeGradleVersion = 1.2-SNAPSHOT
 
 packaging = jar
 info.inceptionYear = 2015

--- a/minecraft/1.8/gradle.properties
+++ b/minecraft/1.8/gradle.properties
@@ -2,6 +2,7 @@ group = nova.core
 
 minecraft.version = 1.8
 forge.version = 11.14.3.1491
+forgeGradleVersion = 1.2-SNAPSHOT
 
 packaging = jar
 info.inceptionYear = 2015

--- a/minecraft/build.gradle
+++ b/minecraft/build.gradle
@@ -1,16 +1,20 @@
-buildscript{
-	repositories{
-		mavenCentral()
-		maven {
-			name "forge"
-			url "http://files.minecraftforge.net/maven"
+subprojects {
+	buildscript {
+		repositories {
+			mavenCentral()
+			maven {
+				name "forge"
+				url "http://files.minecraftforge.net/maven"
+			}
+			maven {
+				name "sonatype"
+				url "https://oss.sonatype.org/content/repositories/snapshots/"
+			}
 		}
-		maven {
-			name "sonatype"
-			url "https://oss.sonatype.org/content/repositories/snapshots/"
+		dependencies {
+			// Minecraft Forge 11.14.3.1503 and newer requires ForgeGradle 2.x,
+			// whereas Minecraft Forge 11.14.3.1502 or older requires ForgeGradle 1.x.
+			classpath 'net.minecraftforge.gradle:ForgeGradle:' + property('forgeGradleVersion')
 		}
-	}
-	dependencies {
-		classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
 	}
 }


### PR DESCRIPTION
This is required for both #234 and to migrate the Minecraft 1.8 wrappers to Minecraft Forge 11.14.4.1563 (the latest recommended Minecraft Forge build for Minecraft 1.8)