### PR TITLE
 Fix compiler warnings

### DIFF
--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/StaticForwarder.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/StaticForwarder.java
@@ -75,10 +75,10 @@ public class StaticForwarder {
 
 	/**
 	 * Used to inject forwarded TileEntites
-	 * @param data
-	 * @param clazz
-	 * @return
-	 * @throws Exception
+	 * @param data The TileEntity data
+	 * @param clazz The TileEntity class
+	 * @return The new TileEntity instance
+	 * @throws Exception If an exception occurred
 	 */
 	public static TileEntity loadTileEntityHook(NBTTagCompound data, Class<? extends TileEntity> clazz) throws Exception {
 		if (clazz.equals(FWTile.class)) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ASMHelper.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ASMHelper.java
@@ -64,8 +64,8 @@ public class ASMHelper {
 
 	static {
 		try {
-			defineClass1 = ClassLoader.class.getDeclaredMethod("defineClass", new Class[] { String.class, byte[].class, int.class, int.class });
-			defineClass2 = ClassLoader.class.getDeclaredMethod("defineClass", new Class[] { String.class, byte[].class, int.class, int.class, ProtectionDomain.class });
+			defineClass1 = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
+			defineClass2 = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class, ProtectionDomain.class);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -135,7 +135,7 @@ public class ASMHelper {
 				if (method == null) {
 					throw new RuntimeException("Method not found: " + injector.method);
 				}
-				Game.logger().info("Injecting into {}\n", injector.method, printInsnList(injector.injection));
+				Game.logger().info("Injecting into {}\n{}", injector.method, printInsnList(injector.injection));
 
 				List<AbstractInsnNode> callNodes;
 				if (injector.before) {
@@ -314,6 +314,7 @@ public class ASMHelper {
 		try {
 			byte[] bytes = createBytes(cn, flags);
 			defineClass1.setAccessible(true);
+			@SuppressWarnings("unchecked")
 			Class<T> clazz = (Class<T>) defineClass1.invoke(Thread.currentThread().getContextClassLoader(), cn.name.replaceAll("/", "."), bytes, 0, bytes.length);
 			defineClass1.setAccessible(false);
 			return clazz;
@@ -329,6 +330,7 @@ public class ASMHelper {
 		try {
 			byte[] bytes = createBytes(cn, flags);
 			defineClass2.setAccessible(true);
+			@SuppressWarnings("unchecked")
 			Class<T> clazz = (Class<T>) defineClass2.invoke(Thread.currentThread().getContextClassLoader(), cn.name.replaceAll("/", "."), bytes, 0, bytes.length, domain);
 			defineClass2.setAccessible(false);
 			return clazz;

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ClassHeirachyManager.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ClassHeirachyManager.java
@@ -59,10 +59,10 @@ public class ClassHeirachyManager implements IClassTransformer {
 	}
 
 	/**
-	 * Returns true if clazz extends, either directly or indirectly, superclass.
+	 * Returns true if the class extends, either directly or indirectly, the superclass.
 	 * @param name The class in question
 	 * @param superclass The class being extended
-	 * @return
+	 * @return If the class extends or not
 	 */
 	public static boolean classExtends(String name, String superclass) {
 		name = toKey(name);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ComponentInjector.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ComponentInjector.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  * The ComponentInjector is capable of creating dynamic classes that implement a
  * specified super class and implement the interfaces specified by
  * {@link Component} and {@link Passthrough}.
- * @param <T>
+ * @param <T> The component type
  * @author Vic Nightfall
  */
 public class ComponentInjector<T> implements Opcodes {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/InsnListPrinter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/InsnListPrinter.java
@@ -123,6 +123,7 @@ public class InsnListPrinter extends Textifier {
 		_visitInsn(insn);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void _visitInsn(AbstractInsnNode insn) {
 		switch (insn.getType()) {
 			case 0:

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ObfMapping.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/ObfMapping.java
@@ -118,6 +118,7 @@ public class ObfMapping {
 		return s_owner.equals(node.owner) && s_name.equals(node.name) && s_desc.equals(node.desc);
 	}
 
+	@SuppressWarnings("deprecation")
 	public AbstractInsnNode toInsn(int opcode) {
 		if (isClass()) {
 			return new TypeInsnNode(opcode, s_owner);
@@ -132,6 +133,7 @@ public class ObfMapping {
 		mv.visitTypeInsn(opcode, s_owner);
 	}
 
+	@SuppressWarnings("deprecation")
 	public void visitMethodInsn(MethodVisitor mv, int opcode) {
 		mv.visitMethodInsn(opcode, s_owner, s_name, s_desc);
 	}

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/TemplateInjector.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/asm/lib/TemplateInjector.java
@@ -44,7 +44,7 @@ public class TemplateInjector {
 	 * @param className - Class that will be injected
 	 * @param template - Default interface used as a template to inject in the templateName
 	 */
-	public void registerTemplate(String className, Class template) {
+	public void registerTemplate(String className, Class<?> template) {
 		templates.put(className, new InjectionTemplate(template.getName()));
 	}
 
@@ -83,8 +83,8 @@ public class TemplateInjector {
 
 		/**
 		 * Patches the cnode withPriority the methods from this template.
-		 * @param cnode
-		 * @return
+		 * @param cnode The ClassNode instance
+		 * @return If the class node was modified
 		 */
 		public boolean inject(ClassNode cnode) {
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ClientProxy.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ClientProxy.java
@@ -23,7 +23,6 @@ package nova.core.wrapper.mc.forge.v17.launcher;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
-import cpw.mods.fml.common.ProgressManager;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -73,8 +72,9 @@ public class ClientProxy extends CommonProxy {
 	@SuppressWarnings({"unchecked", "deprecation"})
 	public void loadLanguage(LanguageManager languageManager) {
 		super.loadLanguage(languageManager);
-		ProgressManager.ProgressBar progressBar = ProgressManager.push("Loading NOVA language files",
-			NovaMinecraftPreloader.novaResourcePacks.size() + 1);
+		cpw.mods.fml.common.ProgressManager.ProgressBar progressBar
+			= cpw.mods.fml.common.ProgressManager.push("Loading NOVA language files",
+				NovaMinecraftPreloader.novaResourcePacks.size() + 1);
 		FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
 		fmlProgressBar.step("nova");
 		SortedSet<Language> languages = Minecraft.getMinecraft().getLanguageManager().getLanguages();
@@ -107,7 +107,7 @@ public class ClientProxy extends CommonProxy {
 			});
 		});
 		fmlProgressBar.finish();
-		ProgressManager.pop(progressBar);
+		cpw.mods.fml.common.ProgressManager.pop(progressBar);
 	}
 
 	private void loadLanguage(LanguageManager languageManager, String langName, InputStream stream) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/FMLProgressBar.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/FMLProgressBar.java
@@ -20,7 +20,6 @@
 
 package nova.core.wrapper.mc.forge.v17.launcher;
 
-import cpw.mods.fml.common.ProgressManager.ProgressBar;
 import nova.core.util.AbstractProgressBar;
 
 /**
@@ -30,9 +29,11 @@ import nova.core.util.AbstractProgressBar;
  */
 public class FMLProgressBar extends AbstractProgressBar {
 
-	private final ProgressBar progressBar;
+	@SuppressWarnings("deprecation")
+	private final cpw.mods.fml.common.ProgressManager.ProgressBar progressBar;
 
-	public FMLProgressBar(ProgressBar progressBar) {
+	public FMLProgressBar(@SuppressWarnings("deprecation")
+		cpw.mods.fml.common.ProgressManager.ProgressBar progressBar) {
 		this.progressBar = progressBar;
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ForgeLoadable.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/ForgeLoadable.java
@@ -29,15 +29,29 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
  *
  * @author ExE Boss
  */
-// TODO Maybe replace with wrapper events.
 public interface ForgeLoadable {
 
-	default void preInit(FMLPreInitializationEvent event) {
+	/**
+	 * Pre‑initialize the wrapper code.
+	 *
+	 * @param evt The Minecraft Forge pre-initialization event
+	 */
+	default void preInit(FMLPreInitializationEvent evt) {
 	}
 
-	default void init(FMLInitializationEvent event) {
+	/**
+	 * Initialize the wrapper code.
+	 *
+	 * @param evt The Minecraft Forge initialization event
+	 */
+	default void init(FMLInitializationEvent evt) {
 	}
 
-	default void postInit(FMLPostInitializationEvent event) {
+	/**
+	 * Post-initialize the wrapper code.
+	 *
+	 * @param evt The Minecraft Forge post-initialization event
+	 */
+	default void postInit(FMLPostInitializationEvent evt) {
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/NovaMinecraft.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/launcher/NovaMinecraft.java
@@ -22,7 +22,6 @@ package nova.core.wrapper.mc.forge.v17.launcher;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.ProgressManager;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -74,7 +73,7 @@ import java.util.stream.Collectors;
  * @author Calclavia
  */
 @Mod(modid = NovaMinecraft.id, name = NovaMinecraft.name, version = NovaMinecraftPreloader.version, acceptableRemoteVersions = "*")
-public class NovaMinecraft {
+public class NovaMinecraft implements ForgeLoadable {
 
 	public static final String id = "nova";
 	public static final String name = "NOVA";
@@ -98,8 +97,12 @@ public class NovaMinecraft {
 	 * ORDER OF LOADING.
 	 *
 	 * 1. Native Loaders 2. Native Converters 3. Mods
+	 *
+	 * @param evt {@inheritDoc}
 	 */
 	@Mod.EventHandler
+	@Override
+	@SuppressWarnings("deprecation")
 	public void preInit(FMLPreInitializationEvent evt) {
 		try {
 			/**
@@ -158,9 +161,10 @@ public class NovaMinecraft {
 				e.printStackTrace();
 			}
 
-			ProgressManager.ProgressBar progressBar = ProgressManager.push("Loading NOVA mods", modClasses.isEmpty() ? 1 : modClasses.size());
+			cpw.mods.fml.common.ProgressManager.ProgressBar progressBar
+				= cpw.mods.fml.common.ProgressManager.push("Loading NOVA mods", modClasses.isEmpty() ? 1 : modClasses.size());
 			launcher.load(new FMLProgressBar(progressBar));
-			ProgressManager.pop(progressBar);
+			cpw.mods.fml.common.ProgressManager.pop(progressBar);
 			novaModWrappers = launcher.getOrdererdMods().stream().filter(mod -> mod instanceof ForgeLoadable).map(mod -> (ForgeLoadable) mod).collect(Collectors.toList());
 			novaWrappers.removeAll(novaModWrappers);
 
@@ -182,7 +186,8 @@ public class NovaMinecraft {
 			Game.entities().init();
 
 			//Load preInit
-			progressBar = ProgressManager.push("Pre-initializing NOVA wrappers", (novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
+			progressBar = cpw.mods.fml.common.ProgressManager.push("Pre-initializing NOVA wrappers",
+				(novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
 			FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
 			novaModWrappers.stream().forEachOrdered(wrapper -> {
 				fmlProgressBar.step(wrapper.getClass());
@@ -193,7 +198,7 @@ public class NovaMinecraft {
 				wrapper.preInit(evt);
 			});
 			fmlProgressBar.finish();
-			ProgressManager.pop(progressBar);
+			cpw.mods.fml.common.ProgressManager.pop(progressBar);
 
 			proxy.preInit(evt);
 
@@ -211,11 +216,15 @@ public class NovaMinecraft {
 	}
 
 	@Mod.EventHandler
+	@Override
+	@SuppressWarnings("deprecation")
 	public void init(FMLInitializationEvent evt) {
 		try {
 			proxy.init(evt);
 			nativeConverters.stream().forEachOrdered(forgeLoadable -> forgeLoadable.init(evt));
-			ProgressManager.ProgressBar progressBar = ProgressManager.push("Initializing NOVA wrappers", (novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
+			cpw.mods.fml.common.ProgressManager.ProgressBar progressBar
+				= cpw.mods.fml.common.ProgressManager.push("Initializing NOVA wrappers",
+					(novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
 			FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
 			novaModWrappers.stream().forEachOrdered(wrapper -> {
 				fmlProgressBar.step(wrapper.getClass());
@@ -226,7 +235,7 @@ public class NovaMinecraft {
 				wrapper.init(evt);
 			});
 			fmlProgressBar.finish();
-			ProgressManager.pop(progressBar);
+			cpw.mods.fml.common.ProgressManager.pop(progressBar);
 		} catch (Exception e) {
 			Game.logger().error("Error during init", e);
 			e.printStackTrace();
@@ -235,12 +244,16 @@ public class NovaMinecraft {
 	}
 
 	@Mod.EventHandler
+	@Override
+	@SuppressWarnings("deprecation")
 	public void postInit(FMLPostInitializationEvent evt) {
 		try {
 			proxy.postInit(evt);
 			nativeConverters.stream().forEachOrdered(forgeLoadable -> forgeLoadable.postInit(evt));
 			Game.recipes().init();
-			ProgressManager.ProgressBar progressBar = ProgressManager.push("Post-initializing NOVA wrappers", (novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
+			cpw.mods.fml.common.ProgressManager.ProgressBar progressBar
+				= cpw.mods.fml.common.ProgressManager.push("Post-initializing NOVA wrappers",
+					(novaModWrappers.isEmpty() ? 1 : novaModWrappers.size()) + novaWrappers.size());
 			FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
 			novaModWrappers.stream().forEachOrdered(wrapper -> {
 				fmlProgressBar.step(wrapper.getClass());
@@ -251,7 +264,7 @@ public class NovaMinecraft {
 				wrapper.postInit(evt);
 			});
 			fmlProgressBar.finish();
-			ProgressManager.pop(progressBar);
+			cpw.mods.fml.common.ProgressManager.pop(progressBar);
 		} catch (Exception e) {
 			Game.logger().error("Error during postInit", e);
 			e.printStackTrace();

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/config/NovaGuiConfig.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/manager/config/NovaGuiConfig.java
@@ -30,6 +30,7 @@ import net.minecraftforge.common.config.Configuration;
  */
 public class NovaGuiConfig extends GuiConfig {
 	public NovaGuiConfig(GuiScreen parentScreen, Configuration config, String modID) {
-		super(parentScreen, new ConfigElement(config.getCategory(Configuration.CATEGORY_GENERAL)).getChildElements(), modID, false, false, GuiConfig.getAbridgedConfigPath(config.toString()));
+		super(parentScreen, new ConfigElement<>(config.getCategory(Configuration.CATEGORY_GENERAL)).getChildElements(),
+			modID, false, false, GuiConfig.getAbridgedConfigPath(config.toString()));
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/ReflectionUtil.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/util/ReflectionUtil.java
@@ -57,6 +57,7 @@ import java.util.logging.Logger;
  * adjustment - as such, those have been collected here.
  * @author Stan Hebben
  */
+@SuppressWarnings("unchecked")
 public class ReflectionUtil {
 	private static final Field NBTTAGLIST_TAGLIST;
 	private static final Field OREDICTIONARY_IDTOSTACK;
@@ -129,6 +130,7 @@ public class ReflectionUtil {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static List getSeeds() {
 		return getPrivateStaticObject(ForgeHooks.class, "seedList");
 	}
@@ -137,7 +139,7 @@ public class ReflectionUtil {
 		return getPrivateStaticObject(ChestGenHooks.class, "chestInfo");
 	}
 
-	public static Map getTranslations() {
+	public static Map<String, String> getTranslations() {
 		return getPrivateObject(
 			getPrivateStaticObject(StatCollector.class, "localizedName", "field_74839_a"),
 			"languageList",
@@ -308,7 +310,7 @@ public class ReflectionUtil {
 	// ### Private Methods ###
 	// #######################
 
-	private static Field getField(Class cls, String... names) {
+	private static Field getField(Class<?> cls, String... names) {
 		for (String name : names) {
 			try {
 				Field field = cls.getDeclaredField(name);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/BlockConverter.java
@@ -97,7 +97,7 @@ public class BlockConverter implements NativeConverter<BlockFactory, net.minecra
 	/**
 	 * Register all Nova blocks
 	 *
-	 * @param evt The Minecraft Forge pre-initialization event
+	 * @param evt {@inheritDoc}
 	 */
 	@Override
 	public void preInit(FMLPreInitializationEvent evt) {

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWTileLoader.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/forward/FWTileLoader.java
@@ -43,7 +43,7 @@ public final class FWTileLoader {
 		try {
 			String blockID = data.getString("novaID");
 			Block block = createBlock(blockID);
-			FWTile tile = injector.inject(block, new Class[0], new Object[0]);
+			FWTile tile = injector.inject(block, new Class<?>[0], new Object[0]);
 			tile.setBlock(block);
 			WrapperEvent.FWTileCreate event = new WrapperEvent.FWTileCreate(block, tile);
 			Game.events().publish(event);
@@ -56,7 +56,7 @@ public final class FWTileLoader {
 	public static FWTile loadTile(String blockID) {
 		try {
 			Block block = createBlock(blockID);
-			FWTile tile = injector.inject(block, new Class[] { String.class }, new Object[] { blockID });
+			FWTile tile = injector.inject(block, new Class<?>[] { String.class }, new Object[] { blockID });
 			tile.setBlock(block);
 			WrapperEvent.FWTileCreate event = new WrapperEvent.FWTileCreate(block, tile);
 			Game.events().publish(event);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/world/BWWorld.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/block/world/BWWorld.java
@@ -121,8 +121,8 @@ public class BWWorld extends World {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Entity addClientEntity(Entity entity) {
-		return NovaMinecraft.proxy.spawnParticle(world(), entity);
+	public <T extends Entity> T addClientEntity(T entity) {
+		return (T) NovaMinecraft.proxy.spawnParticle(world(), entity);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/FWItem.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/FWItem.java
@@ -47,8 +47,9 @@ public class FWItem extends net.minecraft.item.Item implements ItemWrapperMethod
 	}
 
 	@Override
-	public void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
-		ItemWrapperMethods.super.addInformation(itemStack, player, list, p_77624_4_);
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public void addInformation(ItemStack itemStack, EntityPlayer player, List tooltip, boolean advanced) {
+		ItemWrapperMethods.super.addInformation(itemStack, player, tooltip, advanced);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/FWItemBlock.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/FWItemBlock.java
@@ -45,8 +45,9 @@ public class FWItemBlock extends net.minecraft.item.ItemBlock implements ItemWra
 	}
 
 	@Override
-	public void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
-		ItemWrapperMethods.super.addInformation(itemStack, player, list, p_77624_4_);
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public void addInformation(ItemStack itemStack, EntityPlayer player, List tooltip, boolean advanced) {
+		ItemWrapperMethods.super.addInformation(itemStack, player, tooltip, advanced);
 	}
 
 	@Override

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/FWNBTTagCompound.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/FWNBTTagCompound.java
@@ -24,8 +24,6 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import nova.core.item.Item;
 
-import java.util.Iterator;
-
 /**
  * A wrapped NBTTagCompound object that references the item instance
  * @author Stan
@@ -43,15 +41,10 @@ public class FWNBTTagCompound extends NBTTagCompound {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public NBTBase copy() {
 		FWNBTTagCompound result = new FWNBTTagCompound(item);
-		Iterator iterator = this.func_150296_c().iterator();
-
-		while (iterator.hasNext()) {
-			String s = (String) iterator.next();
-			result.setTag(s, getTag(s).copy());
-		}
-
+		((Iterable<String>) func_150296_c()).forEach(s -> result.setTag(s, getTag(s).copy()));
 		return result;
 	}
 }

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemConverter.java
@@ -149,8 +149,12 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 
 	/**
 	 * Saves NOVA item into a Minecraft ItemStack.
+	 *
+	 * @param itemStack the Minecraft ItemStack instance
+	 * @param item The NOVA item.
+	 * @return The updated ItemStack instance
 	 */
-	public net.minecraft.item.ItemStack updateMCItemStack(ItemStack itemStack, nova.core.item.Item item) {
+	public ItemStack updateMCItemStack(ItemStack itemStack, Item item) {
 		itemStack.stackSize = item.count();
 		if (itemStack.stackSize <= 0) {
 			return null;
@@ -162,7 +166,9 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 	}
 
 	/**
-	 * Register all Nova blocks
+	 * Register all Nova items
+	 *
+	 * @param evt {@inheritDoc}
 	 */
 	@Override
 	public void preInit(FMLPreInitializationEvent evt) {
@@ -223,7 +229,8 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 	}
 
 	private void registerMinecraftItemsToNOVA() {
-		Set<String> itemIDs = (Set<String>) net.minecraft.item.Item.itemRegistry.getKeys();
+		@SuppressWarnings("unchecked")
+		Set<String> itemIDs = net.minecraft.item.Item.itemRegistry.getKeys();
 		itemIDs.forEach(itemID -> {
 			net.minecraft.item.Item item = (net.minecraft.item.Item) net.minecraft.item.Item.itemRegistry.getObject(itemID);
 			registerMinecraftMapping(item, 0);

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/item/ItemWrapperMethods.java
@@ -26,16 +26,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
-import nova.core.component.renderer.DynamicRenderer;
 import nova.core.component.renderer.Renderer;
-import nova.core.component.renderer.StaticRenderer;
 import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.util.Direction;
-import nova.core.wrapper.mc.forge.v17.render.RenderUtility;
 import nova.core.wrapper.mc.forge.v17.wrapper.entity.backward.BWEntity;
 import nova.core.wrapper.mc.forge.v17.wrapper.render.BWModel;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
@@ -53,10 +49,17 @@ public interface ItemWrapperMethods extends IItemRenderer {
 
 	ItemFactory getItemFactory();
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	default void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
+	/**
+	 * Allows items to add custom lines of information to the mouseover description
+	 *
+	 * @param itemStack The ItemStack instance
+	 * @param player The player entity
+	 * @param tooltip All lines to display in the Item's tooltip. This is a List of Strings.
+	 * @param advanced Whether the setting "Advanced tooltips" is enabled
+	 */
+	default void addInformation(ItemStack itemStack, EntityPlayer player, List<String> tooltip, boolean advanced) {
 		Item item = ItemConverter.instance().toNova(itemStack);
-		item.setCount(itemStack.stackSize).events.publish(new Item.TooltipEvent(Optional.of(new BWEntity(player)), list));
+		item.setCount(itemStack.stackSize).events.publish(new Item.TooltipEvent(Optional.of(new BWEntity(player)), tooltip));
 		getItemFactory().save(item);
 	}
 

--- a/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/render/BWModel.java
+++ b/minecraft/1.7/src/main/java/nova/core/wrapper/mc/forge/v17/wrapper/render/BWModel.java
@@ -37,12 +37,16 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import java.util.Optional;
 
 /**
+ * BWModel for dynamic rendering
  * @author Calclavia
  */
 public class BWModel extends MeshModel {
 
 	/**
 	 * Completes this rendering for a block.
+	 *
+	 * @param blockAccess The {@link IBlockAccess} instance.
+	 * @throws NullPointerException If {@code blockAccess} is {@code null}
 	 */
 	public void render(IBlockAccess blockAccess) {
 		render(Optional.of(blockAccess), Optional.empty());

--- a/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverterTest.java
+++ b/minecraft/1.7/src/test/java/nova/core/wrapper/mc/forge/v17/wrapper/DirectionConverterTest.java
@@ -22,7 +22,6 @@ package nova.core.wrapper.mc.forge.v17.wrapper;
 
 import net.minecraft.util.EnumFacing;
 import nova.core.util.Direction;
-import nova.internal.core.Game;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,6 +59,7 @@ public class DirectionConverterTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testToNative() {
 		assertThat(converter.toNative(Direction.DOWN)).isEqualTo(EnumFacing.DOWN);
 		assertThat(converter.toNative(Direction.UP)).isEqualTo(EnumFacing.UP);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/StaticForwarder.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/StaticForwarder.java
@@ -79,10 +79,10 @@ public class StaticForwarder {
 
 	/**
 	 * Used to inject forwarded TileEntites
-	 * @param data
-	 * @param clazz
-	 * @return
-	 * @throws Exception
+	 * @param data The TileEntity data
+	 * @param clazz The TileEntity class
+	 * @return The new TileEntity instance
+	 * @throws Exception If an exception occurred
 	 */
 	public static TileEntity loadTileEntityHook(NBTTagCompound data, Class<? extends TileEntity> clazz) throws Exception {
 		if (FWTile.class.isAssignableFrom(clazz)) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ASMHelper.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ASMHelper.java
@@ -64,8 +64,8 @@ public class ASMHelper {
 
 	static {
 		try {
-			defineClass1 = ClassLoader.class.getDeclaredMethod("defineClass", new Class[] { String.class, byte[].class, int.class, int.class });
-			defineClass2 = ClassLoader.class.getDeclaredMethod("defineClass", new Class[] { String.class, byte[].class, int.class, int.class, ProtectionDomain.class });
+			defineClass1 = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
+			defineClass2 = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class, ProtectionDomain.class);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -314,6 +314,7 @@ public class ASMHelper {
 		try {
 			byte[] bytes = createBytes(cn, flags);
 			defineClass1.setAccessible(true);
+			@SuppressWarnings("unchecked")
 			Class<T> clazz = (Class<T>) defineClass1.invoke(Thread.currentThread().getContextClassLoader(), cn.name.replaceAll("/", "."), bytes, 0, bytes.length);
 			defineClass1.setAccessible(false);
 			return clazz;
@@ -329,6 +330,7 @@ public class ASMHelper {
 		try {
 			byte[] bytes = createBytes(cn, flags);
 			defineClass2.setAccessible(true);
+			@SuppressWarnings("unchecked")
 			Class<T> clazz = (Class<T>) defineClass2.invoke(Thread.currentThread().getContextClassLoader(), cn.name.replaceAll("/", "."), bytes, 0, bytes.length, domain);
 			defineClass2.setAccessible(false);
 			return clazz;

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ClassHeirachyManager.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ClassHeirachyManager.java
@@ -59,10 +59,10 @@ public class ClassHeirachyManager implements IClassTransformer {
 	}
 
 	/**
-	 * Returns true if clazz extends, either directly or indirectly, superclass.
+	 * Returns true if the class extends, either directly or indirectly, the superclass.
 	 * @param name The class in question
 	 * @param superclass The class being extended
-	 * @return
+	 * @return If the class extends or not
 	 */
 	public static boolean classExtends(String name, String superclass) {
 		name = toKey(name);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ComponentInjector.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ComponentInjector.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  * The ComponentInjector is capable of creating dynamic classes that implement a
  * specified super class and implement the interfaces specified by
  * {@link Component} and {@link Passthrough}.
- * @param <T>
+ * @param <T> The component type
  * @author Vic Nightfall
  */
 public class ComponentInjector<T> implements Opcodes {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/InsnListPrinter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/InsnListPrinter.java
@@ -123,6 +123,7 @@ public class InsnListPrinter extends Textifier {
 		_visitInsn(insn);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void _visitInsn(AbstractInsnNode insn) {
 		switch (insn.getType()) {
 			case 0:

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ObfMapping.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/ObfMapping.java
@@ -118,6 +118,7 @@ public class ObfMapping {
 		return s_owner.equals(node.owner) && s_name.equals(node.name) && s_desc.equals(node.desc);
 	}
 
+	@SuppressWarnings("deprecation")
 	public AbstractInsnNode toInsn(int opcode) {
 		if (isClass()) {
 			return new TypeInsnNode(opcode, s_owner);
@@ -132,6 +133,7 @@ public class ObfMapping {
 		mv.visitTypeInsn(opcode, s_owner);
 	}
 
+	@SuppressWarnings("deprecation")
 	public void visitMethodInsn(MethodVisitor mv, int opcode) {
 		mv.visitMethodInsn(opcode, s_owner, s_name, s_desc);
 	}

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/TemplateInjector.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/asm/lib/TemplateInjector.java
@@ -44,7 +44,7 @@ public class TemplateInjector {
 	 * @param className - Class that will be injected
 	 * @param template - Default interface used as a template to inject in the templateName
 	 */
-	public void registerTemplate(String className, Class template) {
+	public void registerTemplate(String className, Class<?> template) {
 		templates.put(className, new InjectionTemplate(template.getName()));
 	}
 
@@ -83,8 +83,8 @@ public class TemplateInjector {
 
 		/**
 		 * Patches the cnode withPriority the methods from this template.
-		 * @param cnode
-		 * @return
+		 * @param cnode The ClassNode instance
+		 * @return If the class node was modified
 		 */
 		public boolean inject(ClassNode cnode) {
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ClientProxy.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ClientProxy.java
@@ -23,20 +23,17 @@ package nova.core.wrapper.mc.forge.v18.launcher;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.particle.EntityFX;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.Language;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
-import net.minecraftforge.fml.common.ProgressManager;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import nova.core.entity.Entity;
@@ -82,8 +79,9 @@ public class ClientProxy extends CommonProxy {
 	@SuppressWarnings({"unchecked", "deprecation"})
 	public void loadLanguage(LanguageManager languageManager) {
 		super.loadLanguage(languageManager);
-		ProgressManager.ProgressBar progressBar = ProgressManager.push("Loading NOVA language files",
-			NovaMinecraftPreloader.novaResourcePacks.size() + 1);
+		net.minecraftforge.fml.common.ProgressManager.ProgressBar progressBar =
+			net.minecraftforge.fml.common.ProgressManager.push("Loading NOVA language files",
+				NovaMinecraftPreloader.novaResourcePacks.size() + 1);
 		FMLProgressBar fmlProgressBar = new FMLProgressBar(progressBar);
 		fmlProgressBar.step("nova");
 		SortedSet<Language> languages = Minecraft.getMinecraft().getLanguageManager().getLanguages();
@@ -116,7 +114,7 @@ public class ClientProxy extends CommonProxy {
 			});
 		});
 		fmlProgressBar.finish();
-		ProgressManager.pop(progressBar);
+		net.minecraftforge.fml.common.ProgressManager.pop(progressBar);
 	}
 
 	private void loadLanguage(LanguageManager languageManager, String langName, InputStream stream) {
@@ -133,14 +131,10 @@ public class ClientProxy extends CommonProxy {
 		super.registerItem(item);
 
 		//Hacks to inject custom item definition
-		ModelLoader.setCustomMeshDefinition(item, new ItemMeshDefinition() {
-				@Override
-				public ModelResourceLocation getModelLocation(ItemStack stack) {
-					ResourceLocation itemRL = (ResourceLocation) Item.itemRegistry.getNameForObject(item);
-					return new ModelResourceLocation(itemRL, "inventory");
-				}
-			}
-		);
+		ModelLoader.setCustomMeshDefinition(item, stack -> {
+			ResourceLocation itemRL = (ResourceLocation) Item.itemRegistry.getNameForObject(item);
+			return new ModelResourceLocation(itemRL, "inventory");
+		});
 	}
 
 	@Override
@@ -150,14 +144,10 @@ public class ClientProxy extends CommonProxy {
 		//Hack to inject custom itemblock definition
 		Item itemFromBlock = Item.getItemFromBlock(block);
 
-		ModelLoader.setCustomMeshDefinition(itemFromBlock, new ItemMeshDefinition() {
-				@Override
-				public ModelResourceLocation getModelLocation(ItemStack stack) {
-					ResourceLocation itemRL = (ResourceLocation) Item.itemRegistry.getNameForObject(itemFromBlock);
-					return new ModelResourceLocation(itemRL, "inventory");
-				}
-			}
-		);
+		ModelLoader.setCustomMeshDefinition(itemFromBlock, stack -> {
+			ResourceLocation itemRL = (ResourceLocation) Item.itemRegistry.getNameForObject(itemFromBlock);
+			return new ModelResourceLocation(itemRL, "inventory");
+		});
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/FMLProgressBar.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/FMLProgressBar.java
@@ -20,7 +20,6 @@
 
 package nova.core.wrapper.mc.forge.v18.launcher;
 
-import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
 import nova.core.util.AbstractProgressBar;
 
 /**
@@ -30,9 +29,11 @@ import nova.core.util.AbstractProgressBar;
  */
 public class FMLProgressBar extends AbstractProgressBar {
 
-	private final ProgressBar progressBar;
+	@SuppressWarnings("deprecation")
+	private final net.minecraftforge.fml.common.ProgressManager.ProgressBar progressBar;
 
-	public FMLProgressBar(ProgressBar progressBar) {
+	public FMLProgressBar(@SuppressWarnings("deprecation")
+		net.minecraftforge.fml.common.ProgressManager.ProgressBar progressBar) {
 		this.progressBar = progressBar;
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ForgeLoadable.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/launcher/ForgeLoadable.java
@@ -29,15 +29,29 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
  *
  * @author ExE Boss
  */
-// TODO Maybe replace with wrapper events.
 public interface ForgeLoadable {
 
+	/**
+	 * Pre‑initialize the wrapper code.
+	 *
+	 * @param evt The Minecraft Forge pre-initialization event
+	 */
 	default void preInit(FMLPreInitializationEvent evt) {
 	}
 
+	/**
+	 * Initialize the wrapper code.
+	 *
+	 * @param evt The Minecraft Forge initialization event
+	 */
 	default void init(FMLInitializationEvent evt) {
 	}
 
+	/**
+	 * Post-initialize the wrapper code.
+	 *
+	 * @param evt The Minecraft Forge post-initialization event
+	 */
 	default void postInit(FMLPostInitializationEvent evt) {
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/ReflectionUtil.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/util/ReflectionUtil.java
@@ -57,6 +57,7 @@ import java.util.logging.Logger;
  * adjustment - as such, those have been collected here.
  * @author Stan Hebben
  */
+@SuppressWarnings("unchecked")
 public class ReflectionUtil {
 	private static final Field NBTTAGLIST_TAGLIST;
 	private static final Field OREDICTIONARY_IDTOSTACK;
@@ -129,6 +130,7 @@ public class ReflectionUtil {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static List getSeeds() {
 		return getPrivateStaticObject(ForgeHooks.class, "seedList");
 	}
@@ -137,7 +139,7 @@ public class ReflectionUtil {
 		return getPrivateStaticObject(ChestGenHooks.class, "chestInfo");
 	}
 
-	public static Map getTranslations() {
+	public static Map<String, String> getTranslations() {
 		return getPrivateObject(
 			getPrivateStaticObject(StatCollector.class, "localizedName", "field_74839_a"),
 			"languageList",
@@ -308,7 +310,7 @@ public class ReflectionUtil {
 	// ### Private Methods ###
 	// #######################
 
-	private static Field getField(Class cls, String... names) {
+	private static Field getField(Class<?> cls, String... names) {
 		for (String name : names) {
 			try {
 				Field field = cls.getDeclaredField(name);

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/BlockConverter.java
@@ -97,7 +97,7 @@ public class BlockConverter implements NativeConverter<BlockFactory, net.minecra
 	/**
 	 * Register all Nova blocks
 	 *
-	 * @param evt The Minecraft Forge pre-initialization event
+	 * @param evt {@inheritDoc}
 	 */
 	@Override
 	public void preInit(FMLPreInitializationEvent evt) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/BWWorld.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/block/world/BWWorld.java
@@ -129,8 +129,8 @@ public class BWWorld extends World {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Entity addClientEntity(Entity entity) {
-		return NovaMinecraft.proxy.spawnParticle(world(), entity);
+	public <T extends Entity> T addClientEntity(T entity) {
+		return (T) NovaMinecraft.proxy.spawnParticle(world(), entity);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/FWItem.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/FWItem.java
@@ -47,8 +47,9 @@ public class FWItem extends net.minecraft.item.Item implements ItemWrapperMethod
 	}
 
 	@Override
-	public void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
-		ItemWrapperMethods.super.addInformation(itemStack, player, list, p_77624_4_);
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public void addInformation(ItemStack itemStack, EntityPlayer player, List tooltip, boolean advanced) {
+		ItemWrapperMethods.super.addInformation(itemStack, player, tooltip, advanced);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/FWItemBlock.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/FWItemBlock.java
@@ -45,8 +45,9 @@ public class FWItemBlock extends net.minecraft.item.ItemBlock implements ItemWra
 	}
 
 	@Override
-	public void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
-		ItemWrapperMethods.super.addInformation(itemStack, player, list, p_77624_4_);
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public void addInformation(ItemStack itemStack, EntityPlayer player, List tooltip, boolean advanced) {
+		ItemWrapperMethods.super.addInformation(itemStack, player, tooltip, advanced);
 	}
 
 	@Override

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/FWNBTTagCompound.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/FWNBTTagCompound.java
@@ -41,9 +41,10 @@ public class FWNBTTagCompound extends NBTTagCompound {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public NBTBase copy() {
 		FWNBTTagCompound result = new FWNBTTagCompound(item);
-		getKeySet().forEach(s -> result.setTag((String) s, getTag((String) s).copy()));
+		((Iterable<String>) getKeySet()).forEach(s -> result.setTag(s, getTag(s).copy()));
 		return result;
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemConverter.java
@@ -150,6 +150,10 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 
 	/**
 	 * Saves NOVA item into a Minecraft ItemStack.
+	 *
+	 * @param itemStack the Minecraft ItemStack instance
+	 * @param item The NOVA item.
+	 * @return The updated ItemStack instance
 	 */
 	public ItemStack updateMCItemStack(ItemStack itemStack, Item item) {
 		itemStack.stackSize = item.count();
@@ -164,7 +168,9 @@ public class ItemConverter implements NativeConverter<Item, ItemStack>, ForgeLoa
 	}
 
 	/**
-	 * Register all Nova blocks
+	 * Register all Nova items
+	 *
+	 * @param evt {@inheritDoc}
 	 */
 	@Override
 	public void preInit(FMLPreInitializationEvent evt) {

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemWrapperMethods.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/item/ItemWrapperMethods.java
@@ -27,7 +27,6 @@ import nova.core.item.Item;
 import nova.core.item.ItemFactory;
 import nova.core.util.Direction;
 import nova.core.wrapper.mc.forge.v18.wrapper.entity.backward.BWEntity;
-import nova.internal.core.Game;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.util.List;
@@ -41,10 +40,17 @@ public interface ItemWrapperMethods {
 
 	ItemFactory getItemFactory();
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	default void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean p_77624_4_) {
+	/**
+	 * Allows items to add custom lines of information to the mouseover description
+	 *
+	 * @param itemStack The ItemStack instance
+	 * @param player The player entity
+	 * @param tooltip All lines to display in the Item's tooltip. This is a List of Strings.
+	 * @param advanced Whether the setting "Advanced tooltips" is enabled
+	 */
+	default void addInformation(ItemStack itemStack, EntityPlayer player, List<String> tooltip, boolean advanced) {
 		Item item = ItemConverter.instance().toNova(itemStack);
-		item.setCount(itemStack.stackSize).events.publish(new Item.TooltipEvent(Optional.of(new BWEntity(player)), list));
+		item.setCount(itemStack.stackSize).events.publish(new Item.TooltipEvent(Optional.of(new BWEntity(player)), tooltip));
 		getItemFactory().save(item);
 	}
 

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/BWModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/BWModel.java
@@ -42,6 +42,9 @@ public class BWModel extends MeshModel {
 
 	/**
 	 * Completes this rendering for a block.
+	 *
+	 * @param blockAccess The {@link IBlockAccess} instance.
+	 * @throws NullPointerException If {@code blockAccess} is {@code null}
 	 */
 	public void render(IBlockAccess blockAccess) {
 		render(Optional.of(blockAccess), Optional.empty());

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartBlockModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartBlockModel.java
@@ -22,8 +22,6 @@ package nova.core.wrapper.mc.forge.v18.wrapper.render;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
-import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartBlockModel;
@@ -63,9 +61,12 @@ public class FWSmartBlockModel extends FWSmartModel implements ISmartBlockModel,
 		this.block = block;
 		this.item = item;
 		// Change the default transforms to the default full Block transforms
-		this.itemCameraTransforms = new ItemCameraTransforms(
-			new ItemTransformVec3f(new Vector3f(10, -45, 170), new Vector3f(0, 0.09375f, -0.171875f), new Vector3f(0.375f, 0.375f, 0.375f)), // Third Person
-			ItemTransformVec3f.DEFAULT, ItemTransformVec3f.DEFAULT, ItemTransformVec3f.DEFAULT);
+		this.itemCameraTransforms = new net.minecraft.client.renderer.block.model.ItemCameraTransforms(
+			new net.minecraft.client.renderer.block.model.ItemTransformVec3f(
+				new Vector3f(10, -45, 170), new Vector3f(0, 0.09375f, -0.171875f), new Vector3f(0.375f, 0.375f, 0.375f)), // Third Person
+			net.minecraft.client.renderer.block.model.ItemTransformVec3f.DEFAULT,
+			net.minecraft.client.renderer.block.model.ItemTransformVec3f.DEFAULT,
+			net.minecraft.client.renderer.block.model.ItemTransformVec3f.DEFAULT);
 	}
 
 	//Block rendering

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartItemModel.java
@@ -21,8 +21,6 @@
 package nova.core.wrapper.mc.forge.v18.wrapper.render;
 
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
-import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartItemModel;
@@ -46,11 +44,14 @@ public class FWSmartItemModel extends FWSmartModel implements ISmartItemModel, I
 		super();
 		this.item = item;
 		// Change the default transforms to the default Item transforms
-		this.itemCameraTransforms = new ItemCameraTransforms(
-			new ItemTransformVec3f(new Vector3f(0, -90, 130), new Vector3f(0, 1f / 24f, -2.75f / 16f), new Vector3f(0.9f, 0.9f, 0.9f)), // Third Person
-			new ItemTransformVec3f(new Vector3f(0, -135, 25/*-135/*-25*/), new Vector3f(0, 0.25f, 0.125f/*0.5f, 0.25f*/), new Vector3f(1.7f, 1.7f, 1.7f)), // First Person
-			ItemTransformVec3f.DEFAULT, // Head
-			new ItemTransformVec3f(new Vector3f(-30, 135, 0), new Vector3f(), new Vector3f(1.6F, 1.6F, 1.6F))); // GUI
+		this.itemCameraTransforms = new net.minecraft.client.renderer.block.model.ItemCameraTransforms(
+			new net.minecraft.client.renderer.block.model.ItemTransformVec3f(
+				new Vector3f(0, -90, 130), new Vector3f(0, 1f / 24f, -2.75f / 16f), new Vector3f(0.9f, 0.9f, 0.9f)), // Third Person
+			new net.minecraft.client.renderer.block.model.ItemTransformVec3f(
+				new Vector3f(0, -135, 25/*-135/*-25*/), new Vector3f(0, 0.25f, 0.125f/*0.5f, 0.25f*/), new Vector3f(1.7f, 1.7f, 1.7f)), // First Person
+			net.minecraft.client.renderer.block.model.ItemTransformVec3f.DEFAULT, // Head
+			new net.minecraft.client.renderer.block.model.ItemTransformVec3f(
+				new Vector3f(-30, 135, 0), new Vector3f(), new Vector3f(1.6F, 1.6F, 1.6F))); // GUI
 	}
 
 	//Item rendering

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/FWSmartModel.java
@@ -23,7 +23,6 @@ package nova.core.wrapper.mc.forge.v18.wrapper.render;
 import com.google.common.primitives.Ints;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
@@ -55,7 +54,8 @@ public abstract class FWSmartModel implements IFlexibleBakedModel {
 	protected final VertexFormat format;
 	// Default item transforms. Can be changed in subclasses.
 	@SuppressWarnings("deprecation")
-	protected ItemCameraTransforms itemCameraTransforms = ItemCameraTransforms.DEFAULT;
+	protected net.minecraft.client.renderer.block.model.ItemCameraTransforms itemCameraTransforms
+		= net.minecraft.client.renderer.block.model.ItemCameraTransforms.DEFAULT;
 
 	protected FWSmartModel(VertexFormat format) {
 		this.format = format;
@@ -153,7 +153,7 @@ public abstract class FWSmartModel implements IFlexibleBakedModel {
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public ItemCameraTransforms getItemCameraTransforms() {
+	public net.minecraft.client.renderer.block.model.ItemCameraTransforms getItemCameraTransforms() {
 		return itemCameraTransforms;
 	}
 }

--- a/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/backward/BWBakedModel.java
+++ b/minecraft/1.8/src/main/java/nova/core/wrapper/mc/forge/v18/wrapper/render/backward/BWBakedModel.java
@@ -25,7 +25,6 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
-import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import nova.core.render.Color;
@@ -59,16 +58,16 @@ import java.util.stream.Collectors;
 public class BWBakedModel extends MeshModel {
 
 	@SuppressWarnings("deprecation")
-	public final IBakedModel wrapped;
+	public final net.minecraft.client.resources.model.IBakedModel wrapped;
 
 	public final VertexFormat format;
 
-	public BWBakedModel(@SuppressWarnings("deprecation") IBakedModel wrapped) {
+	public BWBakedModel(@SuppressWarnings("deprecation") net.minecraft.client.resources.model.IBakedModel wrapped) {
 		this(wrapped, DefaultVertexFormats.ITEM);
 	}
 
 	@SuppressWarnings("unchecked")
-	public BWBakedModel(@SuppressWarnings("deprecation") IBakedModel wrapped, VertexFormat format) {
+	public BWBakedModel(@SuppressWarnings("deprecation") net.minecraft.client.resources.model.IBakedModel wrapped, VertexFormat format) {
 		this.wrapped = wrapped;
 		this.format = format;
 		this.matrix.translate(-0.5, -0.5, -0.5);

--- a/src/main/java/nova/core/component/ComponentManager.java
+++ b/src/main/java/nova/core/component/ComponentManager.java
@@ -70,6 +70,10 @@ public class ComponentManager {
 
 	/**
 	 * Internal
+	 *
+	 * @deprecated Internal
+	 * @param nativeObject The native object
+	 * @return The pass-through components
 	 */
 	@Deprecated
 	public Set<Class<? extends Component>> getPassthroughtComponents(Object nativeObject) {

--- a/src/main/java/nova/core/component/ComponentMap.java
+++ b/src/main/java/nova/core/component/ComponentMap.java
@@ -46,9 +46,9 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Adds a new component based on its superclass or interface using dependency injection.
+	 * @param <C> The component type.
 	 * @param componentType The interface or abstract class associated with the new component.
-	 * @param <C> The node type.
-	 * @return A new node of N type.
+	 * @return The added component.
 	 */
 	public final <C extends Component> C add(Class<C> componentType) {
 		return add(Game.injector().resolve(Dependency.dependency(componentType)));
@@ -56,8 +56,9 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Adds a component to the provider.
+	 * @param <C> The component type.
 	 * @param component The component to add.
-	 * @return the component.
+	 * @return The added component.
 	 * @throws ComponentException when the component already exists on the block.
 	 */
 	@SuppressWarnings("unchecked")
@@ -79,16 +80,14 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Adds a component to the block if it is not present.
+	 * @param <C> The component type.
 	 * @param component The component to add.
-	 * @return the component.
+	 * @return The component present on this interface
 	 */
 	@SuppressWarnings("unchecked")
 	public final <C extends Component> C getOrAdd(C component) {
-		if (has(component.getClass())) {
-			return get((Class<C>) component.getClass());
-		}
-
-		return add(component);
+		return getOp((Class<C>) component.getClass())
+			.orElseGet(() -> add(component));
 	}
 
 	/**
@@ -102,6 +101,7 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Removes a component from the block.
+	 * @param <C> The component type.
 	 * @param component The component to remove.
 	 * @return the component removed.
 	 * @throws ComponentException when the component does not exist.
@@ -120,6 +120,7 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Removes the component from the provider.
+	 * @param <C> The component type.
 	 * @param componentType the component type.
 	 * @return the component removed.
 	 * @throws ComponentException when the component does not exist.
@@ -142,6 +143,7 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Gets an optional of the component with the specified type.
+	 * @param <C> The component type.
 	 * @param componentType the type to get.
 	 * @return the optional of the component found or {@code Optional.empty()}.
 	 * if the component was not found.
@@ -166,6 +168,7 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Gets the component with the specified type.
+	 * @param <C> The component type.
 	 * @param componentType the type to get.
 	 * @return the component.
 	 * @throws ComponentException if the component doesn't exist.
@@ -176,6 +179,7 @@ public class ComponentMap extends HashMap<Class<? extends Component>, Component>
 
 	/**
 	 * Gets the set of the components with the specified type.
+	 * @param <C> The component type.
 	 * @param componentType the type to get.
 	 * @return the set of the components.
 	 */

--- a/src/main/java/nova/core/component/SidedComponentMap.java
+++ b/src/main/java/nova/core/component/SidedComponentMap.java
@@ -34,6 +34,11 @@ import java.util.stream.Collectors;
 
 /**
  * A class that contains all sided components.
+ *
+ * This was implemented horribly poorly, so I intend to re‑implement
+ * it in a better way, which will also break backwards compatibility
+ * for the most part.
+ *
  * @author ExE Boss
  */
 public class SidedComponentMap extends ComponentMap {
@@ -102,6 +107,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Adds a component to the provider.
+	 * @param <C> The component type.
 	 * @param direction The direction to add the component to.
 	 * @param component The component to add.
 	 * @return the component.
@@ -113,6 +119,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Adds a component to the provider.
+	 * @param <C> The component type.
 	 * @param component The component to add.
 	 * @param directions The directions to add the component to.
 	 * @return the component.
@@ -126,6 +133,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Adds a component to the block if it is not present.
+	 * @param <C> The component type.
 	 * @param component The component to add.
 	 * @param direction The direction to get or add the component to.
 	 * @return the component.
@@ -156,6 +164,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Removes the component from the block.
+	 * @param <C> The component type.
 	 * @param component the component type.
 	 * @param direction The direction to remove the component from.
 	 * @return the component removed.
@@ -167,6 +176,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Removes the component from the provider.
+	 * @param <C> The component type.
 	 * @param componentType the component type.
 	 * @param direction The direction to remove the component from.
 	 * @return the component removed.
@@ -179,6 +189,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Gets an optional of the component with the specified type.
+	 * @param <C> The component type.
 	 * @param componentType the type to get.
 	 * @param direction The direction to get the component from.
 	 * @return the optional of the component found or {@code Optional.empty()}.
@@ -194,6 +205,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Gets the component with the specified type.
+	 * @param <C> The component type.
 	 * @param componentType the type to get.
 	 * @param direction The direction to get the component from.
 	 * @return the component.
@@ -205,6 +217,7 @@ public class SidedComponentMap extends ComponentMap {
 
 	/**
 	 * Gets the set of the components with the specified type.
+	 * @param <C> The component type.
 	 * @param componentType the type to get.
 	 * @param direction The direction to get the component from.
 	 * @return the set of the components.

--- a/src/main/java/nova/core/component/Updater.java
+++ b/src/main/java/nova/core/component/Updater.java
@@ -33,7 +33,7 @@ public interface Updater {
 		 * Update components
 		 */
 		if (this instanceof ComponentProvider) {
-			((ComponentProvider) this).components()
+			((ComponentProvider<?>) this).components()
 				.stream()
 				.filter(component -> component instanceof Updater)
 				.forEach(component -> ((Updater) component).update(deltaTime));

--- a/src/main/java/nova/core/component/fluid/Fluid.java
+++ b/src/main/java/nova/core/component/fluid/Fluid.java
@@ -54,6 +54,7 @@ public class Fluid implements Identifiable, Storable, Cloneable {
 	 * Sets new size of this FluidStack
 	 * Note that there can never be fluid with "zero" amount. Use Optional.empty() instead.
 	 * @param amount New size
+	 * @return {@code this} instance
 	 */
 	public Fluid setAmount(int amount) {
 		this.amount = Math.max(amount, 1);

--- a/src/main/java/nova/core/component/fluid/FluidBlock.java
+++ b/src/main/java/nova/core/component/fluid/FluidBlock.java
@@ -29,6 +29,7 @@ public interface FluidBlock {
 
 	/**
 	 * Returns the Fluid associated with this Block.
+	 * @return The Fluid associated with this Block.
 	 */
 	Optional<Fluid> getFluid();
 
@@ -38,7 +39,7 @@ public interface FluidBlock {
 	 * NOTE: The block is intended to handle its own state changes.
 	 *
 	 * @param doDrain If false, the drain will only be simulated.
-	 * @return
+	 * @return The drained fluid amount.
 	 */
 	Optional<Fluid> drain(boolean doDrain);
 }

--- a/src/main/java/nova/core/component/inventory/InventoryException.java
+++ b/src/main/java/nova/core/component/inventory/InventoryException.java
@@ -23,6 +23,8 @@ package nova.core.component.inventory;
 import nova.core.util.exception.NovaException;
 
 public class InventoryException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public InventoryException() {
 		super();
 	}

--- a/src/main/java/nova/core/component/inventory/ItemFilter.java
+++ b/src/main/java/nova/core/component/inventory/ItemFilter.java
@@ -34,10 +34,10 @@ public interface ItemFilter extends Predicate<Item> {
 
 	/**
 	 * Returns an {@link ItemFilter} that accepts an {@link Item} of the same
-	 * type as the provided.
+	 * type as  provided.
 	 *
-	 * @param item
-	 * @return ItemFilter
+	 * @param item The item type
+	 * @return The ItemFilter instance checking the item type
 	 */
 	static ItemFilter of(Item item) {
 		return item::sameItemType;
@@ -47,8 +47,8 @@ public interface ItemFilter extends Predicate<Item> {
 	 * Returns an {@link ItemFilter} that accepts an {@link Item} of the same
 	 * type as provided.
 	 *
-	 * @param id
-	 * @return ItemFilter
+	 * @param id The item ID
+	 * @return The ItemFilter instance checking the item ID
 	 */
 	static ItemFilter of(String id) {
 		return (other) -> id.equals(other.getID());
@@ -57,8 +57,8 @@ public interface ItemFilter extends Predicate<Item> {
 	/**
 	 * Accepts any {@link Item} that has a &gt;= stack size than provided.
 	 *
-	 * @param amount
-	 * @return
+	 * @param amount The amount
+	 * @return The ItemFilter instance checking the amount
 	 */
 	static ItemFilter of(int amount) {
 		return (other) -> other.count() >= amount;

--- a/src/main/java/nova/core/component/misc/Collider.java
+++ b/src/main/java/nova/core/component/misc/Collider.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
 
 @UnsidedComponent
 public class Collider extends Component {
-	public final ComponentProvider provider;
+	public final ComponentProvider<?> provider;
 
 	/**
 	 * A general cuboid that represents the bounds of this object.
@@ -66,7 +66,7 @@ public class Collider extends Component {
 	 */
 	public Supplier<Boolean> isOpaqueCube = isCube;
 
-	public Collider(ComponentProvider provider) {
+	public Collider(ComponentProvider<?> provider) {
 		this.provider = provider;
 	}
 

--- a/src/main/java/nova/core/component/transform/Orientation.java
+++ b/src/main/java/nova/core/component/transform/Orientation.java
@@ -43,7 +43,6 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.math3.util.FastMath;
 
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -259,6 +258,10 @@ public class Orientation extends Component implements Storable, Stateful, Syncab
 
 	/**
 	 * Rotatable Block
+	 *
+	 * @param side The hit side
+	 * @param hit The hit vector
+	 * @return If rotation is possible from this side
 	 */
 	public boolean rotate(int side, Vector3D hit) {
 		int result = getSideToRotate(side, hit);
@@ -274,6 +277,10 @@ public class Orientation extends Component implements Storable, Stateful, Syncab
 
 	/**
 	 * Determines the side to rotate based on the hit vector on the block.
+	 *
+	 * @param hitSide The hit side
+	 * @param hit The hit vector
+	 * @return The rotation axis
 	 */
 	public int getSideToRotate(int hitSide, Vector3D hit) {
 		int tBack = hitSide ^ 1;

--- a/src/main/java/nova/core/config/ConfigException.java
+++ b/src/main/java/nova/core/config/ConfigException.java
@@ -23,6 +23,8 @@ package nova.core.config;
 import nova.core.util.exception.NovaException;
 
 public class ConfigException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public ConfigException() {
 		super();
 	}

--- a/src/main/java/nova/core/deps/DependencyException.java
+++ b/src/main/java/nova/core/deps/DependencyException.java
@@ -23,6 +23,8 @@ package nova.core.deps;
 import nova.core.util.exception.NovaException;
 
 public class DependencyException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public DependencyException() {
 		super();
 	}

--- a/src/main/java/nova/core/entity/component/RigidBody.java
+++ b/src/main/java/nova/core/entity/component/RigidBody.java
@@ -34,6 +34,8 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 public abstract class RigidBody extends Component implements Updater {
 	/**
 	 * Mass in kilograms. Default is 1 kg.
+	 *
+	 * @return The mass of this rigid body.
 	 */
 	public abstract double getMass();
 
@@ -41,6 +43,8 @@ public abstract class RigidBody extends Component implements Updater {
 
 	/**
 	 * Velocity is how fast the body is moving
+	 *
+	 * @return The velocity vector of this rigid body.
 	 */
 	public abstract Vector3D getVelocity();
 
@@ -52,6 +56,8 @@ public abstract class RigidBody extends Component implements Updater {
 
 	/**
 	 * Gravity is an acceleration.
+	 *
+	 * @return The gravity vector of this rigid body.
 	 */
 	public abstract Vector3D getGravity();
 
@@ -59,6 +65,8 @@ public abstract class RigidBody extends Component implements Updater {
 
 	/**
 	 * Rotation Methods
+	 *
+	 * @return The angular drag of this rigid body.
 	 */
 	public abstract double getAngularDrag();
 
@@ -70,6 +78,8 @@ public abstract class RigidBody extends Component implements Updater {
 
 	/**
 	 * Forces
+	 *
+	 * @param force The force to apply.
 	 */
 	public abstract void addForce(Vector3D force);
 
@@ -78,28 +88,61 @@ public abstract class RigidBody extends Component implements Updater {
 	public abstract void addTorque(Vector3D torque);
 
 	/**
-	 * Scala sugar coating
+	 * Alias for {@link #getMass()}.
+	 *
+	 * @return The mass of this rigid body.
+	 * @see #getMass()
 	 */
 	public final double mass() {
 		return getMass();
 	}
 
+	/**
+	 * Alias for {@link #getVelocity()}.
+	 *
+	 * @return The velocity vector of this rigid body.
+	 * @see #getVelocity()
+	 */
 	public final Vector3D velocity() {
 		return getVelocity();
 	}
 
+	/**
+	 * Alias for {@link #getDrag()}.
+	 *
+	 * @return The drag of this rigid body.
+	 * @see #getDrag()
+	 */
 	public final double drag() {
 		return getDrag();
 	}
 
+	/**
+	 * Alias for {@link #getGravity()}.
+	 *
+	 * @return The gravity vector of this rigid body.
+	 * @see #getGravity()
+	 */
 	public final Vector3D gravity() {
 		return getGravity();
 	}
 
+	/**
+	 * Alias for {@link #getAngularDrag()}.
+	 *
+	 * @return The angular drag of this rigid body.
+	 * @see #getAngularDrag()
+	 */
 	public final double angularDrag() {
 		return getAngularDrag();
 	}
 
+	/**
+	 * Alias for {@link #getAngularVelocity()}.
+	 *
+	 * @return The angular velocity of this rigid body.
+	 * @see #getAngularVelocity()
+	 */
 	public final Rotation angularVelocity() {
 		return getAngularVelocity();
 	}

--- a/src/main/java/nova/core/event/bus/EventBus.java
+++ b/src/main/java/nova/core/event/bus/EventBus.java
@@ -216,6 +216,7 @@ public class EventBus<T> {
 		 * @return The event handler
 		 */
 		public synchronized EventListenerHandle<T> bind(EventListener<E> list) {
+			@SuppressWarnings("unchecked")
 			EventListener<T> listener = clazz.isPresent() ? new TypedEventListener<>(list, clazz.get()) : (EventListener) list;
 
 			if (name != null && unsortedListeners.stream().filter(node -> node.name != null).anyMatch(node -> node.name.equals(name))) {

--- a/src/main/java/nova/core/event/bus/EventCancelException.java
+++ b/src/main/java/nova/core/event/bus/EventCancelException.java
@@ -21,6 +21,8 @@
 package nova.core.event.bus;
 
 public class EventCancelException extends EventException {
+	private static final long serialVersionUID = 1L;
+
 	public EventCancelException(String message, Class<? extends Event> event) {
 		super(message, event);
 	}

--- a/src/main/java/nova/core/event/bus/EventException.java
+++ b/src/main/java/nova/core/event/bus/EventException.java
@@ -23,6 +23,8 @@ package nova.core.event.bus;
 import nova.core.util.exception.NovaException;
 
 public class EventException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public EventException() {
 		super();
 	}

--- a/src/main/java/nova/core/game/InputManager.java
+++ b/src/main/java/nova/core/game/InputManager.java
@@ -57,7 +57,8 @@ public abstract class InputManager {
 	/**
 	 * Is the key current down?
 	 *
-	 * @return
+	 * @param key The {@link Key key} to check.
+	 * @return The pressed state of the key.
 	 */
 	public abstract boolean isKeyDown(Key key);
 

--- a/src/main/java/nova/core/item/Item.java
+++ b/src/main/java/nova/core/item/Item.java
@@ -81,6 +81,7 @@ public class Item extends ComponentProvider<ComponentMap> implements Identifiabl
 	/**
 	 * Sets new size of this ItemStack
 	 * @param size New size
+	 * @return {@code this} instance
 	 */
 	public Item setCount(int size) {
 		count = Math.max(Math.min(getMaxCount(), size), 0);

--- a/src/main/java/nova/core/nativewrapper/NativeManager.java
+++ b/src/main/java/nova/core/nativewrapper/NativeManager.java
@@ -113,6 +113,7 @@ public class NativeManager {
 	 * Converts a native object to a nova object. This method has autocast, is DANGEROUS and may crash.
 	 *
 	 * @param nativeObject A game implementation object.
+	 * @param <T> The NOVA equivalent type.
 	 * @return The NOVA equivalent object.
 	 */
 	public <T> T toNova(Object nativeObject) {
@@ -129,6 +130,7 @@ public class NativeManager {
 	 * Converts a nova object to a native object. This method has autocast, is DANGEROUS and may crash.
 	 *
 	 * @param novaObject A NOVA implementation object.
+	 * @param <T> The game equivalent type.
 	 * @return The game equivalent object.
 	 */
 	public <T> T toNative(Object novaObject) {

--- a/src/main/java/nova/core/network/NetworkException.java
+++ b/src/main/java/nova/core/network/NetworkException.java
@@ -22,7 +22,10 @@ package nova.core.network;
 
 import nova.core.util.exception.NovaException;
 
+
 public class NetworkException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public NetworkException() {
 		super();
 	}

--- a/src/main/java/nova/core/network/NetworkManager.java
+++ b/src/main/java/nova/core/network/NetworkManager.java
@@ -46,7 +46,8 @@ public abstract class NetworkManager {
 	 * Register a packet type. A packet type handles
 	 * a specific packet handler type.
 	 *
-	 * @param type An ID is assigned to the packet handler
+	 * @param type The packet handler to register
+	 * @return The ID of the packet handler
 	 */
 	public int register(PacketHandler<?> type) {
 		handlers.add(type);
@@ -104,11 +105,12 @@ public abstract class NetworkManager {
 	 */
 	public abstract void sendPacket(Packet packet);
 
+	@SuppressWarnings("unchecked")
 	public Packet writePacket(Object sender, Packet packet) {
 		int packetTypeID = getPacketTypeID(getPacketType(sender));
 		packet.writeInt(packetTypeID);
 		packet.writeInt(packet.getID());
-		((PacketHandler) getPacketType(sender)).write(sender, packet);
+		((PacketHandler<Object>) getPacketType(sender)).write(sender, packet);
 		return packet;
 	}
 

--- a/src/main/java/nova/core/network/NetworkTarget.java
+++ b/src/main/java/nova/core/network/NetworkTarget.java
@@ -52,7 +52,8 @@ public @interface NetworkTarget {
 	 * A side specifies the current scope of the execution environment. Use
 	 * {@link #get()} to check your current side in order to react differently
 	 * on the server or client side. Some methods may only be run on a specific
-	 * side, see {@link #assertSide(Side)}.
+	 * side, see {@link #assertSide(nova.core.network.NetworkTarget.Side)
+	 * assertSide(Side)}.
 	 * </p>
 	 *
 	 * <p>
@@ -195,7 +196,7 @@ public @interface NetworkTarget {
 		/**
 		 * Shorthand for {@code Side.assertSide(this)}
 		 *
-		 * @see #assertSide(Side)
+		 * @see #assertSide(nova.core.network.NetworkTarget.Side)
 		 */
 		public void assertSide() {
 			Side current = get();

--- a/src/main/java/nova/core/recipes/ingredient/ItemIngredient.java
+++ b/src/main/java/nova/core/recipes/ingredient/ItemIngredient.java
@@ -118,8 +118,10 @@ public interface ItemIngredient {
 	Optional<String> getTag();
 
 	/**
-	 * Sets the ingredient tag. Ingredients can be tagged to make them easy to read from recipe functions.
+	 * Sets the ingredient tag. Ingredients can be tagged to make them
+	 * easy to read from recipe functions.
 	 *
+	 * @param tag The ingredient tag
 	 * @return this instance
 	 */
 	public ItemIngredient withTag(String tag);

--- a/src/main/java/nova/core/render/RenderException.java
+++ b/src/main/java/nova/core/render/RenderException.java
@@ -23,6 +23,8 @@ package nova.core.render;
 import nova.core.util.exception.NovaException;
 
 public class RenderException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public RenderException() {
 		super();
 	}

--- a/src/main/java/nova/core/render/pipeline/BlockRenderPipeline.java
+++ b/src/main/java/nova/core/render/pipeline/BlockRenderPipeline.java
@@ -138,7 +138,7 @@ public class BlockRenderPipeline extends RenderPipeline {
 	 *
 	 * @param renderSide A predicate that takes a {@link nova.core.util.Direction}
 	 * and returns a boolean specifying whether or not the side should render.
-	 * @return
+	 * @return this
 	 */
 	public BlockRenderPipeline filter(Predicate<Direction> renderSide) {
 		this.renderSide = renderSide;

--- a/src/main/java/nova/core/render/pipeline/ItemRenderPipeline.java
+++ b/src/main/java/nova/core/render/pipeline/ItemRenderPipeline.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
  */
 public class ItemRenderPipeline extends RenderPipeline {
 
-	public final ComponentProvider componentProvider;
+	public final ComponentProvider<?> componentProvider;
 
 	/**
 	 * Called to get the texture of this item.
@@ -64,7 +64,7 @@ public class ItemRenderPipeline extends RenderPipeline {
 	 */
 	public Supplier<Color> colorMultiplier = () -> Color.white;
 
-	public ItemRenderPipeline(ComponentProvider componentProvider) {
+	public ItemRenderPipeline(ComponentProvider<?> componentProvider) {
 		this.componentProvider = componentProvider;
 		size = () -> new Vector2D(1, 1);
 		consumer = model -> model.addChild(draw(new MeshModel()));

--- a/src/main/java/nova/core/retention/Data.java
+++ b/src/main/java/nova/core/retention/Data.java
@@ -219,11 +219,12 @@ public class Data extends HashMap<String, Object> {
 	 * Loads an object from its stored data, given its class.
 	 * @param clazz - The class to load
 	 * @param data - The data
+	 * @param <T> - The type
 	 * @return The object loaded with given data.
 	 */
 	public static <T extends Storable> T unserialize(Class<T> clazz, Data data) {
 		try {
-			T storable = clazz.newInstance();
+			T storable = clazz.getDeclaredConstructor().newInstance();
 			storable.load(data);
 			return storable;
 		} catch (Exception e) {
@@ -324,7 +325,7 @@ public class Data extends HashMap<String, Object> {
 		try {
 			@SuppressWarnings("unchecked")
 			Class<T> storableClass = (Class<T>) Class.forName(storableData.className);
-			T obj = storableClass.newInstance();
+			T obj = storableClass.getDeclaredConstructor().newInstance();
 			obj.load(storableData);
 			return obj;
 		} catch (Exception e) {

--- a/src/main/java/nova/core/retention/Storable.java
+++ b/src/main/java/nova/core/retention/Storable.java
@@ -88,7 +88,7 @@ public interface Storable {
 							if (List.class.isAssignableFrom(type)) {
 								field.set(this, Data.unserialize((Data) value));
 							} else {
-								Collection<?> collection = (Collection) type.newInstance();
+								Collection<?> collection = (Collection) type.getDeclaredConstructor().newInstance();
 								field.set(this, collection.addAll(Data.unserialize((Data) value)));
 							}
 						} else {

--- a/src/main/java/nova/core/util/ClassLoaderUtil.java
+++ b/src/main/java/nova/core/util/ClassLoaderUtil.java
@@ -61,6 +61,8 @@ public class ClassLoaderUtil {
 	}
 
 	public static class ClassLoaderException extends NovaException {
+		private static final long serialVersionUID = 1L;
+
 		public ClassLoaderException() {
 			super();
 		}

--- a/src/main/java/nova/core/util/EnumSelector.java
+++ b/src/main/java/nova/core/util/EnumSelector.java
@@ -52,6 +52,8 @@ public class EnumSelector<T extends Enum<T>> implements Iterable<T> {
 	/**
 	 * Creates a new instance of EnumSelector for the given type.
 	 *
+	 * @param <T> The enum type
+	 * @param enumClass The enum class for which to create an EnumSelector.
 	 * @return an instance of EnumSelector for the given type.
 	 */
 	public static <T extends Enum<T>> EnumSelector<T> of(Class<T> enumClass) {

--- a/src/main/java/nova/core/util/Pipeline.java
+++ b/src/main/java/nova/core/util/Pipeline.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 /**
  * A series of methods that transform an object as it is passed through the {@link Pipeline}.
  * @author Calclavia
+ * @param <O> The pipeline type.
  */
 public class Pipeline<O> {
 	protected Optional<Pipeline<O>> prev = Optional.empty();
@@ -29,6 +30,7 @@ public class Pipeline<O> {
 	/**
 	 * Sets the given pipeline to be piped after this render stream.
 	 * This method essentially allow you to switch between processes in the pipeline.
+	 * @param <T> The new pipeline type.
 	 * @param stream The stream to apply.
 	 * @return The new RenderStream
 	 */

--- a/src/main/java/nova/core/util/ProgressBar.java
+++ b/src/main/java/nova/core/util/ProgressBar.java
@@ -58,6 +58,8 @@ public interface ProgressBar {
 
 	/**
 	 * Check if the progress bar has been finished.
+	 *
+	 * @return If the progress bar has finished.
 	 */
 	boolean isFinished();
 

--- a/src/main/java/nova/core/util/RayTracer.java
+++ b/src/main/java/nova/core/util/RayTracer.java
@@ -89,6 +89,7 @@ public class RayTracer {
 
 	/**
 	 * Check all blocks that are in a line
+	 * @param world The world to perform the ray trace in.
 	 * @return The blocks ray traced in the order from closest to furthest.
 	 */
 	public Stream<RayTraceBlockResult> rayTraceBlocks(World world) {
@@ -171,7 +172,9 @@ public class RayTracer {
 
 	/**
 	 * Ray traces a cuboid
+	 * @param <R> the result type
 	 * @param cuboid The cuboid in absolute world coordinates
+	 * @param resultMapper the {@link RayTraceResult} converter
 	 * @return The ray trace result if the ray intersects the cuboid
 	 */
 	public <R extends RayTraceResult> Optional<R> rayTrace(Cuboid cuboid, BiFunction<Vector3D, Cuboid, R> resultMapper) {

--- a/src/main/java/nova/core/util/ReflectionUtil.java
+++ b/src/main/java/nova/core/util/ReflectionUtil.java
@@ -267,7 +267,7 @@ public class ReflectionUtil {
 			if (args != null && args.length > 0) {
 				return newInstanceMatching(findMatchingConstructor(clazz, types(args)).get(), args);
 			} else {
-				return clazz.newInstance();
+				return clazz.getDeclaredConstructor().newInstance();
 			}
 		} catch (Exception e) {
 			throw new ReflectionException(e);
@@ -279,7 +279,7 @@ public class ReflectionUtil {
 			if (args != null && args.length > 0) {
 				return clazz.getConstructor(types(args)).newInstance(args);
 			}
-			return clazz.newInstance();
+			return clazz.getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new ReflectionException(e);
 		}
@@ -304,6 +304,7 @@ public class ReflectionUtil {
 	 * Gets all the annotated fields of this class, including all the parents
 	 * classes in the order of hierarchy.
 	 *
+	 * @param <T> The annotation type
 	 * @param annotation Your annotation class.
 	 * @param clazz Class to search through.
 	 * @return An ordered map of annotated fields and their annotations from the
@@ -329,6 +330,8 @@ public class ReflectionUtil {
 	}
 
 	public static class ReflectionException extends NovaException {
+		private static final long serialVersionUID = 1L;
+
 		public ReflectionException() {
 			super();
 		}

--- a/src/main/java/nova/core/util/collection/EvictingList.java
+++ b/src/main/java/nova/core/util/collection/EvictingList.java
@@ -26,6 +26,8 @@ import java.util.LinkedList;
  * @param <E> Type contained in the list
  */
 public class EvictingList<E> extends LinkedList<E> {
+	private static final long serialVersionUID = 1L;
+
 	private final int limit;
 
 	/**

--- a/src/main/java/nova/core/util/collection/TreeNode.java
+++ b/src/main/java/nova/core/util/collection/TreeNode.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  *
  * @param <S> - Self type
  */
-public class TreeNode<S extends TreeNode> implements Iterable<S> {
+public class TreeNode<S extends TreeNode<S>> implements Iterable<S> {
 
 	/**
 	 * The children of the node.
@@ -71,9 +71,10 @@ public class TreeNode<S extends TreeNode> implements Iterable<S> {
 	 * @param node The childnode to add
 	 * @return The merged node
 	 */
+	@SuppressWarnings("unchecked")
 	public S addChild(S node) {
 		children.add(node);
-		node.parent = Optional.of(this);
+		node.parent = Optional.of((S) this);
 		return node;
 	}
 

--- a/src/main/java/nova/core/util/exception/RegistrationException.java
+++ b/src/main/java/nova/core/util/exception/RegistrationException.java
@@ -24,6 +24,8 @@ package nova.core.util.exception;
  * An exception thrown when registration in a manager, dictionary or registry fails.
  */
 public class RegistrationException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public RegistrationException() {
 		super();
 	}

--- a/src/main/java/nova/core/util/math/MatrixStack.java
+++ b/src/main/java/nova/core/util/math/MatrixStack.java
@@ -42,8 +42,8 @@ public class MatrixStack implements Transformer {
 	 * Clone construcotr of MatrixStack
 	 * @param clone instance to be cloned
 	 */
+	@SuppressWarnings("unchecked")
 	public MatrixStack(MatrixStack clone) {
-		//noinspection unchecked
 		this.stack = (Stack<RealMatrix>) clone.stack.clone();
 		this.current = clone.current.copy();
 	}

--- a/src/main/java/nova/core/util/math/MatrixUtil.java
+++ b/src/main/java/nova/core/util/math/MatrixUtil.java
@@ -55,6 +55,8 @@ public class MatrixUtil {
     // Little cheat.
     private static Localizable of(String string) {
         return new Localizable() {
+			private static final long serialVersionUID = 1L;
+
             @Override
             public String getSourceString() {
                 return string;

--- a/src/main/java/nova/core/util/math/RotationUtil.java
+++ b/src/main/java/nova/core/util/math/RotationUtil.java
@@ -79,7 +79,10 @@ public class RotationUtil {
 	}
 
 	/**
-	 * Reverse of rotateSide
+	 * Rotates a Direction global size into a relative side.
+	 * @param s1 Side 1
+	 * @param s2 Side 2
+	 * @return The Direction ordinal from 0-5.
 	 */
 	public static int rotationTo(int s1, int s2) {
 		if ((s1 & 6) == (s2 & 6)) {
@@ -106,6 +109,11 @@ public class RotationUtil {
 	 * Wrapper function that simply calls {@code slerp(a, b, t, true)}.
 	 * <p>
 	 * See {@link #slerp(Rotation, Rotation, double, boolean)} for details.
+	 *
+	 * @param a the first Rotation
+	 * @param b the second Rotation
+	 * @param t the temporal interpolation parameter
+	 * @return The slerp interpolation of Rotations {@code a} and {@code b}, at time {@code t}.
 	 */
 	public static Rotation slerp(Rotation a, Rotation b, double t) {
 		return slerp(a, b, t, true);
@@ -123,11 +131,12 @@ public class RotationUtil {
 	 * "flipping" the source Rotation if needed.
 	 * @param a the first Rotation
 	 * @param b the second Rotation
-	 * @param t the t interpolation parameter
+	 * @param t the temporal interpolation parameter
 	 * @param allowFlip tells whether or not the interpolation allows axis flip
+	 * @return The slerp interpolation of Rotations {@code a} and {@code b}, at time {@code t}.
 	 */
 	public static Rotation slerp(Rotation a, Rotation b, double t, boolean allowFlip) {
-		// Warning: this method should not normalize the Rotation
+		// TODO: this method should not normalize the Rotation
 		double cosAngle = dotProduct(a, b);
 
 		double c1, c2;
@@ -156,7 +165,9 @@ public class RotationUtil {
 	 * Returns the "dot" product of this Quaternion and {@code b}:
 	 * <p>
 	 * {@code this.x * b.x + this.y * b.y + this.z * b.z + this.w * b.w}
+	 * @param a This
 	 * @param b the Quaternion
+	 * @return The dot product
 	 */
 	public static double dotProduct(Rotation a, Rotation b) {
 		return a.getQ0() * b.getQ0() + a.getQ1() * b.getQ1() + a.getQ2() * b.getQ2() + a.getQ3() * b.getQ3();

--- a/src/main/java/nova/core/world/World.java
+++ b/src/main/java/nova/core/world/World.java
@@ -77,29 +77,45 @@ public abstract class World implements Identifiable {
 	/**
 	 * Creates an entity
 	 * @param factory The entity factory
+	 * @return The added entity
 	 */
 	public abstract Entity addEntity(EntityFactory factory);
 
 	/**
 	 * Creates an entity that holds an item
+	 * @param position The position to add the item to
 	 * @param item The item
+	 * @return The added entity
 	 */
 	public abstract Entity addEntity(Vector3D position, Item item);
 
 	/**
 	 * Creates an entity only on the client side.
 	 * For example, particle effects.
+	 * <p>
+	 * <b>TODO:</b> Replace this with an actual particle system.
+	 * </p>
+	 * @param factory The entity factory
+	 * @return The added entity
 	 */
 	public abstract Entity addClientEntity(EntityFactory factory);
 
 	/**
 	 * Creates an entity only on the client side.
 	 * For example, particle effects.
+	 * <p>
+	 * <b>TODO:</b> Replace this with an actual particle system.
+	 * </p>
+	 * @param <T> The entity type
+	 * @param entity The entity to add
+	 * @return The added entity
 	 */
 	public abstract <T extends Entity> T addClientEntity(T entity);
 
 	/**
 	 * Destroys an entity, removing it from the world.
+	 *
+	 * @param entity The entity to remove
 	 */
 	public abstract void removeEntity(Entity entity);
 

--- a/src/main/java/nova/internal/core/Game.java
+++ b/src/main/java/nova/internal/core/Game.java
@@ -75,15 +75,11 @@ public class Game {
 
 	/**
 	 * The synchronized ticker that uses the same thread as the game.
-	 *
-	 * This is @deprecated, use syncTicker() instead.
 	 */
 	private final UpdateTicker.SynchronizedTicker syncTicker;
 
 	/**
 	 * The thread ticker that runs on NOVA's thread.
-	 *
-	 * This is @deprecated, use threadTicker() instead.
 	 */
 	private final UpdateTicker.ThreadTicker threadTicker;
 
@@ -224,6 +220,11 @@ public class Game {
 
 	/**
 	 * The synchronized ticker that uses the same thread as the game.
+	 *
+	 * @return The synchronous game ticker, which is synchronized
+	 * with the game’s tick speed.
+	 * <p>
+	 * For Minecraft, this is 20hz.
 	 */
 	public static UpdateTicker.SynchronizedTicker syncTicker() {
 		return instance.syncTicker;
@@ -231,6 +232,9 @@ public class Game {
 
 	/**
 	 * The thread ticker that runs on NOVA's thread.
+	 *
+	 * @return The asynchronous NOVA ticker,
+	 * which runs as fast as possible.
 	 */
 	public static UpdateTicker.ThreadTicker threadTicker() {
 		return instance.threadTicker;

--- a/src/main/java/nova/internal/core/di/DICoreModule.java
+++ b/src/main/java/nova/internal/core/di/DICoreModule.java
@@ -25,13 +25,9 @@ import se.jbee.inject.bind.BinderModule;
 import java.util.function.Supplier;
 
 public class DICoreModule extends BinderModule {
-
-
 	@Override
 	protected void declare() {
-
 		//install(BuildinBundle.PROVIDER); //To allow injection of providers
-		starbind(Supplier.class).to(new SupplierSupplier());
+		starbind(Supplier.class).to(new SupplierModule.SupplierSupplier());
 	}
-
 }

--- a/src/main/java/nova/internal/core/di/SupplierModule.java
+++ b/src/main/java/nova/internal/core/di/SupplierModule.java
@@ -16,7 +16,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with NOVA.  If not, see <http://www.gnu.org/licenses/>.
- */package nova.internal.core.di;
+ */
+
+package nova.internal.core.di;
 
 import se.jbee.inject.Dependency;
 import se.jbee.inject.Injector;
@@ -25,20 +27,28 @@ import se.jbee.inject.bootstrap.SuppliedBy;
 
 import static se.jbee.inject.util.ToString.describe;
 
-final class SupplierSupplier implements Supplier<java.util.function.Supplier<?>> {
+/**
+ * A dummy class containing the {@link SupplierSupplier} to match
+ * the rest of the NOVA Dependency Injection setup.
+ *
+ * @author ExE Boss
+ */
+public final class SupplierModule {
 
-	@Override
-	public java.util.function.Supplier<?> supply( Dependency<? super java.util.function.Supplier<?>> dependency, Injector injector ) {
-		Dependency<?> providedType = dependency.onTypeParameter();
-		if ( !dependency.getName().isDefault() ) {
-			providedType = providedType.named( dependency.getName() );
+	public static final class SupplierSupplier implements Supplier<java.util.function.Supplier<?>> {
+		@Override
+		public java.util.function.Supplier<?> supply(Dependency<? super java.util.function.Supplier<?>> dependency, Injector injector) {
+			Dependency<?> providedType = dependency.onTypeParameter();
+			if (!dependency.getName().isDefault()) {
+				providedType = providedType.named(dependency.getName());
+			}
+			final Dependency<?> finalProvidedType = providedType;
+			return () -> SuppliedBy.lazyProvider(finalProvidedType.uninject().ignoredExpiry(), injector).provide();
 		}
-		final Dependency<?> finalProvidedType = providedType;
-		return () -> SuppliedBy.lazyProvider(finalProvidedType.uninject().ignoredExpiry(), injector).provide();
-	}
 
-	@Override
-	public String toString() {
-		return describe( "supplies", java.util.function.Supplier.class );
+		@Override
+		public String toString() {
+			return describe("supplies", java.util.function.Supplier.class);
+		}
 	}
 }

--- a/src/main/java/nova/internal/core/launch/InitializationException.java
+++ b/src/main/java/nova/internal/core/launch/InitializationException.java
@@ -21,6 +21,8 @@
 import nova.core.util.exception.NovaException;
 
 public class InitializationException extends NovaException {
+	private static final long serialVersionUID = 1L;
+
 	public InitializationException() {
 		super();
 	}

--- a/src/main/java/nova/internal/core/util/InjectionUtil.java
+++ b/src/main/java/nova/internal/core/util/InjectionUtil.java
@@ -185,9 +185,9 @@ public class InjectionUtil {
 	 * @param <T> The object type
 	 * @param classToConstruct The class to construct
 	 * @return A new instance of the class
-	 * @throws InstantiationException
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
+	 * @throws InstantiationException If an {@link InstantiationException} occurs
+	 * @throws IllegalAccessException If an {@link IllegalAccessException} occurs
+	 * @throws InvocationTargetException If an {@link InvocationTargetException} occurs
 	 * @see Constructor#newInstance(java.lang.Object...)
 	 */
 	@SuppressWarnings("unchecked")
@@ -204,9 +204,9 @@ public class InjectionUtil {
 	 * @param classToConstruct The class to construct
 	 * @param mapping Custom DI mapping
 	 * @return A new instance of the class
-	 * @throws InstantiationException
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
+	 * @throws InstantiationException If an {@link InstantiationException} occurs
+	 * @throws IllegalAccessException If an {@link IllegalAccessException} occurs
+	 * @throws InvocationTargetException If an {@link InvocationTargetException} occurs
 	 * @see Constructor#newInstance(java.lang.Object...)
 	 */
 	@SuppressWarnings("unchecked")

--- a/src/main/java/nova/internal/core/util/TopologicalSort.java
+++ b/src/main/java/nova/internal/core/util/TopologicalSort.java
@@ -21,7 +21,8 @@ public class TopologicalSort {
 	 * Sort the input graph into a topologically sorted list
 	 *
 	 * Uses the reverse depth first search as outlined in ...
-	 * @param graph
+	 * @param <T> The type
+	 * @param graph The graph to sort
 	 * @return The sorted list.
 	 */
 	public static <T> List<T> topologicalSort(DirectedGraph<T> graph) {
@@ -64,6 +65,7 @@ public class TopologicalSort {
 			}
 
 			throw new NovaException("There was a cycle detected in the input graph, sorting is not possible", node) {
+				private static final long serialVersionUID = 1L;
 			};
 		}
 


### PR DESCRIPTION
This PR fixes all remaining compiler warnings in the rest of NOVA-Core.

A lot of the warnings were related to either Javadoc or raw types, the rest were unchecked conversion.

---

Follow up to #278, fixes #184.

Also, the build is _painfully_ slow.